### PR TITLE
Adds `Wishart` and `InverseWishart` distributions

### DIFF
--- a/src/distribution/inverse_wishart.rs
+++ b/src/distribution/inverse_wishart.rs
@@ -35,6 +35,14 @@ impl InverseWishart {
         }
     }
 
+    pub fn freedom(&self) -> f64 {
+        self.freedom
+    }
+
+    pub fn scale(&self) -> &DMatrix<f64> {
+        &self.scale
+    }
+
     pub fn p(&self) -> usize {
         self.scale.nrows()
     }

--- a/src/distribution/inverse_wishart.rs
+++ b/src/distribution/inverse_wishart.rs
@@ -1,0 +1,328 @@
+use std::f64::consts::LN_2;
+use nalgebra::{Cholesky, DMatrix, Dynamic};
+use rand::Rng;
+use crate::{Result, StatsError};
+use crate::distribution::Continuous;
+use crate::distribution::wishart::Wishart;
+use crate::function::gamma::{mvgamma, mvlgamma};
+use crate::statistics::{MeanN, Mode, VarianceN};
+
+/// Implements the [Inverse Wishart distribution](http://en.wikipedia.org/wiki/Inverse-Wishart_distribution)
+#[derive(Debug, Clone)]
+pub struct InverseWishart {
+    freedom: f64,
+    scale: DMatrix<f64>,
+    chol: Cholesky<f64, Dynamic>,
+}
+
+impl InverseWishart {
+    pub fn new(freedom: f64, scale: DMatrix<f64>) -> Result<Self> {
+        if scale.nrows() != scale.ncols() {
+            return Err(StatsError::BadParams);
+        }
+        if freedom <= 0.0 || freedom.is_nan() {
+            return Err(StatsError::ArgMustBePositive("degree of freedom must be positive"));
+        }
+        if freedom <= scale.nrows() as f64 - 1.0 {
+            return Err(StatsError::ArgGt("degree of freedom must be greater than p-1", freedom));
+        }
+
+        match Cholesky::new(scale.clone()) {
+            None => Err(StatsError::BadParams),
+            Some(chol) => {
+                Ok(InverseWishart { freedom, scale, chol })
+            }
+        }
+    }
+
+    pub fn p(&self) -> usize {
+        self.scale.nrows()
+    }
+}
+
+impl MeanN<DMatrix<f64>> for InverseWishart {
+    fn mean(&self) -> Option<DMatrix<f64>> {
+        Some(&self.scale * (1.0 / (self.freedom - self.p() as f64 - 1.0)))
+    }
+}
+
+impl VarianceN<DMatrix<f64>> for InverseWishart {
+    fn variance(&self) -> Option<DMatrix<f64>> {
+        let p = self.p() as f64;
+
+        Some(self.scale.map_with_location(|i, j, x| {
+            let n1 = ((self.freedom - p + 1.0) * x.powi(2)) + ((self.freedom - p - 1.0) * self.scale[(i, i)] * self.scale[(j, j)]);
+            let n2 = (self.freedom - p) * (self.freedom - p - 1.0) * (self.freedom - p - 1.0) * (self.freedom - p - 3.0);
+            n1 / n2
+        }))
+    }
+}
+
+impl Mode<DMatrix<f64>> for InverseWishart {
+    fn mode(&self) -> DMatrix<f64> {
+        &self.scale * (1.0 / (self.freedom + self.p() as f64 + 1.0))
+    }
+}
+
+impl ::rand::distributions::Distribution<DMatrix<f64>> for InverseWishart {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> DMatrix<f64> {
+        let w = Wishart::new(
+            self.freedom,
+            self.scale.clone().try_inverse().unwrap(), // We already know S is positive definite
+        ).unwrap();
+
+        w.sample(rng).pseudo_inverse(1e-4).unwrap()
+    }
+}
+
+impl Continuous<DMatrix<f64>, f64> for InverseWishart {
+    fn pdf(&self, x: DMatrix<f64>) -> f64 {
+        let p = self.p() as f64;
+        let chol = Cholesky::new(x).expect("x is not positive definite");
+        let x_det = chol.determinant();
+        let sxi = chol.solve(&self.scale);
+
+        x_det.powf(-(self.freedom + p + 1.0) / 2.0)
+            * (-0.5 * sxi.trace()).exp()
+            * self.chol.determinant().powf(self.freedom / 2.0)
+            / (2.0f64).powf(self.freedom * p / 2.0)
+            / mvgamma(p as i64, self.freedom / 2.0)
+    }
+
+    fn ln_pdf(&self, x: DMatrix<f64>) -> f64 {
+        let p = self.p() as f64;
+        let chol = Cholesky::new(x).expect("x is not positive definite");
+        let x_lndet = chol.determinant().ln();
+        let sxi = chol.solve(&self.scale);
+
+        x_lndet * -(self.freedom + p + 1.0) / 2.0
+            - 0.5 * sxi.trace()
+            + self.chol.determinant().ln() * (self.freedom / 2.0)
+            - LN_2 * (self.freedom * p / 2.0)
+            - mvlgamma(p as i64, self.freedom / 2.0)
+    }
+}
+
+
+#[rustfmt::skip]
+#[cfg(test)]
+mod tests {
+    use nalgebra::DMatrix;
+    use rand::distributions::Distribution;
+    use rand::rngs::StdRng;
+    use rand::SeedableRng;
+    use crate::distribution::Continuous;
+    use crate::distribution::inverse_wishart::InverseWishart;
+    use crate::statistics::{MeanN, Mode, VarianceN};
+
+    fn try_create(freedom: f64, scale: DMatrix<f64>) -> InverseWishart
+    {
+        let w = InverseWishart::new(freedom, scale);
+        assert!(w.is_ok());
+        w.unwrap()
+    }
+
+    fn test_almost<F>(
+        freedom: f64,
+        scale: DMatrix<f64>,
+        expected: f64,
+        acc: f64,
+        eval: F,
+    ) where
+        F: FnOnce(InverseWishart) -> f64,
+    {
+        let mvn = try_create(freedom, scale);
+        let x = eval(mvn);
+        assert_almost_eq!(expected, x, acc);
+    }
+
+    fn test_almost_mat<F>(
+        freedom: f64,
+        scale: DMatrix<f64>,
+        expected: DMatrix<f64>,
+        acc: f64,
+        eval: F,
+    ) where
+        F: FnOnce(InverseWishart) -> DMatrix<f64>,
+    {
+        let mvn = try_create(freedom, scale);
+        let x = eval(mvn);
+
+        for i in 0..x.nrows() {
+            for j in 0..x.ncols() {
+                assert_almost_eq!(expected[(i, j)], x[(i, j)], acc);
+            }
+        }
+    }
+
+    #[test]
+    fn test_mean() {
+        test_almost_mat(
+            6.0, DMatrix::from_row_slice(2, 2, &[1.0, 0.0, 0.0, 1.0]),
+            DMatrix::from_row_slice(2, 2, &[
+                0.333333, 0.0,
+                0.0, 0.333333
+            ]),
+            1e-5, |w| w.mean().unwrap(),
+        );
+        test_almost_mat(
+            7.0, DMatrix::from_row_slice(3, 3, &[
+                1.0143, 0.0000, 0.0000,
+                0.0000, 0.2034, 0.0000,
+                0.0000, 0.0000, 0.9495
+            ]),
+            DMatrix::from_row_slice(3, 3, &[
+                0.3381, 0.0, 0.0,
+                0.0, 0.0678, 0.0,
+                0.0, 0.0, 0.3165,
+            ]),
+            1e-5, |w| w.mean().unwrap(),
+        );
+    }
+
+    #[test]
+    fn test_mode() {
+        test_almost_mat(
+            6.0, DMatrix::from_row_slice(2, 2, &[1.0, 0.0, 0.0, 1.0]),
+            DMatrix::from_row_slice(2, 2, &[
+                0.111111, 0.0,
+                0.0, 0.111111
+            ]),
+            1e-5, |w| w.mode(),
+        );
+        test_almost_mat(
+            7.0, DMatrix::from_row_slice(3, 3, &[
+                1.0143, 0.0000, 0.0000,
+                0.0000, 0.2034, 0.0000,
+                0.0000, 0.0000, 0.9495
+            ]),
+            DMatrix::from_row_slice(3, 3, &[
+                0.0922091, 0.0, 0.0,
+                0.0, 0.0184909, 0.0,
+                0.0, 0.0, 0.0863182,
+            ]),
+            1e-5, |w| w.mode(),
+        );
+    }
+
+    #[test]
+    fn test_variance() {
+        test_almost_mat(
+            6.0, DMatrix::from_row_slice(2, 2, &[1.0, 0.0, 0.0, 1.0]),
+            DMatrix::from_row_slice(2, 2, &[
+                0.222222, 0.0833333,
+                0.0833333, 0.222222
+            ]),
+            1e-5, |w| w.variance().unwrap(),
+        );
+        test_almost_mat(
+            7.0, DMatrix::from_row_slice(3, 3, &[
+                1.0143, 0.0000, 0.0000,
+                0.0000, 0.2034, 0.0000,
+                0.0000, 0.0000, 0.9495
+            ]),
+            DMatrix::from_row_slice(3, 3, &[
+                0.228623, 0.0171924, 0.0802565,
+                0.0171924, 0.00919368, 0.016094,
+                0.0802565, 0.016094, 0.200344,
+            ]),
+            1e-5, |w| w.variance().unwrap(),
+        );
+    }
+
+    #[test]
+    fn test_pdf() {
+        test_almost(
+            2.0, DMatrix::from_row_slice(2, 2, &[1.0, 0.0, 0.0, 1.0]),
+            0.02927491576215958,
+            1e-15, |w| w.pdf(DMatrix::from_row_slice(2, 2, &[1.0, 0.0, 0.0, 1.0])),
+        );
+        test_almost(
+            2.0, DMatrix::from_row_slice(2, 2, &[1.0, 0.0, 0.0, 1.0]),
+            -3.5310242469692907,
+            1e-15, |w| w.ln_pdf(DMatrix::from_row_slice(2, 2, &[1.0, 0.0, 0.0, 1.0])),
+        );
+
+        test_almost(
+            6.0, DMatrix::from_row_slice(2, 2, &[1.0, 0.0, 0.0, 1.0]),
+            0.0012197881567566496,
+            1e-15, |w| w.pdf(DMatrix::from_row_slice(2, 2, &[1.0, 0.0, 0.0, 1.0])),
+        );
+        test_almost(
+            6.0, DMatrix::from_row_slice(2, 2, &[1.0, 0.0, 0.0, 1.0]),
+            -6.709078077317236,
+            1e-13, |w| w.ln_pdf(DMatrix::from_row_slice(2, 2, &[1.0, 0.0, 0.0, 1.0])),
+        );
+
+        test_almost(
+            3.0, DMatrix::from_row_slice(3, 3, &[
+                1.0143, 0.0000, 0.0000,
+                0.0000, 0.2034, 0.0000,
+                0.0000, 0.0000, 0.9495
+            ]),
+            0.04313330476055326,
+            1e-12, |w| w.pdf(DMatrix::from_row_slice(3, 3, &[
+                0.7121, 0.0000, 0.0000,
+                0.0000, 0.4010, 0.0000,
+                0.0000, 0.0000, 0.5627,
+            ])),
+        );
+        test_almost(
+            3.0, DMatrix::from_row_slice(3, 3, &[
+                1.0143, 0.0000, 0.0000,
+                0.0000, 0.2034, 0.0000,
+                0.0000, 0.0000, 0.9495
+            ]),
+            -3.1434598480128795,
+            1e-12, |w| w.ln_pdf(DMatrix::from_row_slice(3, 3, &[
+                0.7121, 0.0000, 0.0000,
+                0.0000, 0.4010, 0.0000,
+                0.0000, 0.0000, 0.5627,
+            ])),
+        );
+
+        test_almost(
+            3.0, DMatrix::from_row_slice(3, 3, &[
+                1.0143, 0.0000, 0.0000,
+                0.0000, 0.2034, 0.0000,
+                0.0000, 0.0000, 0.9495
+            ]),
+            3.3174174014586637e-7,
+            1e-12, |w| w.pdf(DMatrix::from_row_slice(3, 3, &[
+                1.7121, 0.0000, 0.0000,
+                0.0000, 0.4010, 0.0000,
+                0.0000, 0.0000, 9.5627,
+            ])),
+        );
+        test_almost(
+            3.0, DMatrix::from_row_slice(3, 3, &[
+                1.0143, 0.0000, 0.0000,
+                0.0000, 0.2034, 0.0000,
+                0.0000, 0.0000, 0.9495
+            ]),
+            -14.91890906187113,
+            1e-12, |w| w.ln_pdf(DMatrix::from_row_slice(3, 3, &[
+                1.7121, 0.0000, 0.0000,
+                0.0000, 0.4010, 0.0000,
+                0.0000, 0.0000, 9.5627,
+            ])),
+        );
+    }
+
+    #[test]
+    fn test_sample() {
+        let w = try_create(4.0, DMatrix::from_row_slice(3, 3, &[
+            1.0143, 0.0000, 0.0000,
+            0.0000, 0.2034, 0.0000,
+            0.0000, 0.0000, 0.9495
+        ]));
+
+        let mut rng = StdRng::seed_from_u64(42);
+
+        for _ in 0..100 {
+            let sample = w.sample(&mut rng);
+            let l_prob = w.ln_pdf(sample);
+            assert!(l_prob.is_finite());
+        }
+    }
+}

--- a/src/distribution/mod.rs
+++ b/src/distribution/mod.rs
@@ -70,6 +70,7 @@ mod weibull;
 mod ziggurat;
 mod ziggurat_tables;
 mod wishart;
+mod inverse_wishart;
 
 use crate::Result;
 

--- a/src/distribution/mod.rs
+++ b/src/distribution/mod.rs
@@ -69,6 +69,7 @@ mod uniform;
 mod weibull;
 mod ziggurat;
 mod ziggurat_tables;
+mod wishart;
 
 use crate::Result;
 

--- a/src/distribution/mod.rs
+++ b/src/distribution/mod.rs
@@ -34,6 +34,8 @@ pub use self::students_t::StudentsT;
 pub use self::triangular::Triangular;
 pub use self::uniform::Uniform;
 pub use self::weibull::Weibull;
+pub use self::wishart::Wishart;
+pub use self::inverse_wishart::InverseWishart;
 
 mod bernoulli;
 mod beta;

--- a/src/distribution/wishart.rs
+++ b/src/distribution/wishart.rs
@@ -1,0 +1,330 @@
+use std::f64::consts::LN_2;
+use nalgebra::{Cholesky, DMatrix, DVector, Dynamic};
+use num_traits::Float;
+use num_traits::real::Real;
+use rand::Rng;
+use crate::{Result, StatsError};
+use crate::consts::LN_PI;
+use crate::distribution::{ChiSquared, Continuous, Normal, ziggurat};
+use crate::function::gamma::{digamma, mvgamma};
+use crate::statistics::{MeanN, Mode, VarianceN};
+use crate::function::gamma::mvlgamma;
+
+fn mvdigamma(p: i64, a: f64) -> f64 {
+    let mut sum = 0.0;
+    for i in 0..p {
+        sum += digamma(a - (i as f64) / 2.0);
+    }
+    sum
+}
+
+
+/// Implements the [Wishart distribution](http://en.wikipedia.org/wiki/Wishart_distribution)
+#[derive(Debug, Clone)]
+pub struct Wishart {
+    df: f64,
+    S: DMatrix<f64>,
+    chol: Cholesky<f64, Dynamic>,
+}
+
+impl Wishart {
+    pub fn new(df: f64, S: DMatrix<f64>) -> Result<Self> {
+        if S.nrows() != S.ncols() {
+            return Err(StatsError::BadParams);
+        }
+        if df <= 0.0 || df.is_nan() {
+            return Err(StatsError::ArgMustBePositive("df must be positive"));
+        }
+        if df <= S.nrows() as f64 - 1.0 {
+            return Err(StatsError::ArgGt("df must be greater than p-1", df));
+        }
+
+        match Cholesky::new(S.clone()) {
+            None => Err(StatsError::BadParams),
+            Some(chol) => {
+                Ok(Wishart { df, S, chol })
+            }
+        }
+    }
+
+    pub fn p(&self) -> usize {
+        self.S.nrows()
+    }
+
+    pub fn entropy(&self) -> Option<f64> {
+        let p = self.p() as f64;
+        Some(
+            (p + 1.0) / 2.0 * self.chol.determinant().ln()
+                + 0.5 * p * (p + 1.0) * LN_2
+                + mvlgamma(p as i64, self.df / 2.0)
+                - (self.df - p - 1.0) / 2.0 * mvdigamma(p as i64, self.df / 2.0)
+                + self.df * p / 2.0
+        )
+    }
+}
+
+impl MeanN<DMatrix<f64>> for Wishart {
+    fn mean(&self) -> Option<DMatrix<f64>> {
+        Some(self.df * &self.S)
+    }
+}
+
+impl VarianceN<DMatrix<f64>> for Wishart {
+    fn variance(&self) -> Option<DMatrix<f64>> {
+        Some(self.S.map_with_location(|i, j, x| {
+            self.df * (self.S[(i, i)] * self.S[(j, j)] + x.powi(2))
+        }))
+    }
+}
+
+impl Mode<DMatrix<f64>> for Wishart {
+    fn mode(&self) -> DMatrix<f64> {
+        (self.df - self.p() as f64 - 1.0) * &self.S
+    }
+}
+
+impl ::rand::distributions::Distribution<DMatrix<f64>> for Wishart {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> DMatrix<f64> {
+        let p = self.p();
+        let mut A = DMatrix::zeros(p, p);
+
+        for i in 0..p {
+            A[(i, i)] = ChiSquared::new(self.df - i as f64).unwrap().sample(rng);
+        }
+
+        for i in 1..p {
+            for j in 0..i {
+                A[(i, j)] = ziggurat::sample_std_normal(rng);
+            }
+        }
+
+        let L = self.chol.l();
+        &L * &A * A.transpose() * L.transpose()
+    }
+}
+
+impl Continuous<DMatrix<f64>, f64> for Wishart {
+    fn pdf(&self, x: DMatrix<f64>) -> f64 {
+        let p = self.p() as f64;
+        let x_det = x.determinant();
+        let x_sol = self.chol.solve(&x);
+
+        x_det.powf((self.df - p - 1.0) / 2.0)
+            * (-0.5 * x_sol.trace()).exp()
+            / (2.0f64).powf(self.df * p / 2.0)
+            / self.chol.determinant().powf(self.df / 2.0)
+            / mvgamma(p as i64, self.df / 2.0)
+    }
+
+    fn ln_pdf(&self, x: DMatrix<f64>) -> f64 {
+        let p = self.p() as f64;
+        let x_lndet = x.determinant().ln();
+        let x_sol = self.chol.solve(&x);
+
+        x_lndet * (self.df - p - 1.0) / 2.0
+            - 0.5 * x_sol.trace()
+            - LN_2 * (self.df * p / 2.0)
+            - self.chol.determinant().ln() * (self.df / 2.0)
+            - mvlgamma(p as i64, self.df / 2.0)
+    }
+}
+
+#[rustfmt::skip]
+#[cfg(test)]
+mod tests {
+    use nalgebra::DMatrix;
+    use rand::distributions::Distribution;
+    use rand::rngs::StdRng;
+    use rand::SeedableRng;
+    use crate::distribution::Continuous;
+    use crate::distribution::wishart::Wishart;
+    use crate::statistics::{MeanN, VarianceN};
+
+    fn try_create(df: f64, S: DMatrix<f64>) -> Wishart
+    {
+        let w = Wishart::new(df, S);
+        assert!(w.is_ok());
+        w.unwrap()
+    }
+
+    fn test_almost<F>(
+        df: f64,
+        S: DMatrix<f64>,
+        expected: f64,
+        acc: f64,
+        eval: F,
+    ) where
+        F: FnOnce(Wishart) -> f64,
+    {
+        let mvn = try_create(df, S);
+        let x = eval(mvn);
+        assert_almost_eq!(expected, x, acc);
+    }
+
+    fn test_almost_mat<F>(
+        df: f64,
+        S: DMatrix<f64>,
+        expected: DMatrix<f64>,
+        acc: f64,
+        eval: F,
+    ) where
+        F: FnOnce(Wishart) -> DMatrix<f64>,
+    {
+        let mvn = try_create(df, S);
+        let x = eval(mvn);
+
+        for i in 0..x.nrows() {
+            for j in 0..x.ncols() {
+                assert_almost_eq!(expected[(i, j)], x[(i, j)], acc);
+            }
+        }
+    }
+
+    #[test]
+    fn test_variance() {
+        test_almost_mat(
+            2.0, DMatrix::from_row_slice(2, 2, &[1.0, 0.0, 0.0, 1.0]),
+            DMatrix::from_row_slice(2, 2, &[4.0, 2.0, 2.0, 4.0]),
+            1e-15, |w| w.variance().unwrap(),
+        );
+        test_almost_mat(
+            3.0, DMatrix::from_row_slice(3, 3, &[
+                1.0143, 0.0000, 0.0000,
+                0.0000, 0.2034, 0.0000,
+                0.0000, 0.0000, 0.9495
+            ]),
+            DMatrix::from_row_slice(3, 3, &[
+                6.17283, 0.618926, 2.88923,
+                0.618926, 0.248229, 0.579385,
+                2.88923, 0.579385, 5.4093,
+            ]),
+            1e-4, |w| w.variance().unwrap(),
+        );
+    }
+
+    #[test]
+    fn test_entropy() {
+        test_almost(
+            2.0, DMatrix::from_row_slice(2, 2, &[1.0, 0.0, 0.0, 1.0]),
+            3.9538085820677584,
+            1e-14, |w| w.entropy().unwrap(),
+        );
+        test_almost(
+            3.0, DMatrix::from_row_slice(3, 3, &[
+                1.0143, 0.0000, 0.0000,
+                0.0000, 0.2034, 0.0000,
+                0.0000, 0.0000, 0.9495
+            ]), 6.315039109555716,
+            1e-12, |w| w.entropy().unwrap(),
+        );
+        test_almost(
+            3.0, DMatrix::from_row_slice(3, 3, &[
+                1.0143, 0.0000, 0.0000,
+                0.0000, 0.2034, 0.0000,
+                0.0000, 0.0000, 9.9495
+            ]), 11.013723204318477,
+            1e-12, |w| w.entropy().unwrap(),
+        );
+    }
+
+    #[test]
+    fn test_mode() {
+        test_almost_mat(
+            2.0, DMatrix::from_row_slice(2, 2, &[1.0, 0.0, 0.0, 1.0]),
+            DMatrix::from_row_slice(2, 2, &[2.0, 0.0, 0.0, 2.0]),
+            1e-15, |w| w.mean().unwrap(),
+        );
+    }
+
+    #[test]
+    fn test_pdf() {
+        test_almost(
+            2.0, DMatrix::from_row_slice(2, 2, &[1.0, 0.0, 0.0, 1.0]),
+            0.02927491576215958,
+            1e-15, |w| w.pdf(DMatrix::from_row_slice(2, 2, &[1.0, 0.0, 0.0, 1.0])),
+        );
+        test_almost(
+            2.0, DMatrix::from_row_slice(2, 2, &[1.0, 0.0, 0.0, 1.0]),
+            0.02927491576215958,
+            1e-15, |w| w.pdf(DMatrix::from_row_slice(2, 2, &[1.0, 0.0, 0.0, 1.0])),
+        );
+        test_almost(
+            3.0, DMatrix::from_row_slice(3, 3, &[
+                1.0143, 0.0000, 0.0000,
+                0.0000, 0.2034, 0.0000,
+                0.0000, 0.0000, 0.9495
+            ]),
+            0.028397507846420644,
+            1e-12, |w| w.pdf(DMatrix::from_row_slice(3, 3, &[
+                0.7121, 0.0000, 0.0000,
+                0.0000, 0.4010, 0.0000,
+                0.0000, 0.0000, 0.5627,
+            ])),
+        );
+        test_almost(
+            3.0, DMatrix::from_row_slice(3, 3, &[
+                1.0143, 0.0000, 0.0000,
+                0.0000, 0.2034, 0.0000,
+                0.0000, 0.0000, 0.9495
+            ]),
+            2.3729077174800438e-5,
+            1e-12, |w| w.pdf(DMatrix::from_row_slice(3, 3, &[
+                1.7121, 0.0000, 0.0000,
+                0.0000, 0.4010, 0.0000,
+                0.0000, 0.0000, 9.5627,
+            ])),
+        );
+    }
+
+    #[test]
+    fn test_ln_pdf() {
+        test_almost(
+            2.0, DMatrix::from_row_slice(2, 2, &[1.0, 0.0, 0.0, 1.0]),
+            -3.5310242469692907,
+            1e-15, |w| w.ln_pdf(DMatrix::from_row_slice(2, 2, &[1.0, 0.0, 0.0, 1.0])),
+        );
+        test_almost(
+            3.0, DMatrix::from_row_slice(3, 3, &[
+                1.0143, 0.0000, 0.0000,
+                0.0000, 0.2034, 0.0000,
+                0.0000, 0.0000, 0.9495
+            ]),
+            -3.561453889551996,
+            1e-12, |w| w.ln_pdf(DMatrix::from_row_slice(3, 3, &[
+                0.7121, 0.0000, 0.0000,
+                0.0000, 0.4010, 0.0000,
+                0.0000, 0.0000, 0.5627,
+            ])),
+        );
+        test_almost(
+            3.0, DMatrix::from_row_slice(3, 3, &[
+                1.0143, 0.0000, 0.0000,
+                0.0000, 0.2034, 0.0000,
+                0.0000, 0.0000, 0.9495
+            ]),
+            -10.648809376818907,
+            1e-12, |w| w.ln_pdf(DMatrix::from_row_slice(3, 3, &[
+                1.7121, 0.0000, 0.0000,
+                0.0000, 0.4010, 0.0000,
+                0.0000, 0.0000, 9.5627,
+            ])),
+        );
+    }
+
+    #[test]
+    fn test_sample() {
+        let w = try_create(4.0, DMatrix::from_row_slice(3, 3, &[
+            1.0143, 0.0000, 0.0000,
+            0.0000, 0.2034, 0.0000,
+            0.0000, 0.0000, 0.9495
+        ]));
+
+        let mut rng = StdRng::seed_from_u64(42);
+
+        for i in 0..100 {
+            let sample = w.sample(&mut rng);
+            let l_prob = w.ln_pdf(sample);
+            assert!(l_prob.is_finite());
+        }
+    }
+}

--- a/src/distribution/wishart.rs
+++ b/src/distribution/wishart.rs
@@ -47,6 +47,14 @@ impl Wishart {
         }
     }
 
+    pub fn freedom(&self) -> f64 {
+        self.freedom
+    }
+
+    pub fn scale(&self) -> &DMatrix<f64> {
+        &self.scale
+    }
+
     pub fn p(&self) -> usize {
         self.scale.nrows()
     }

--- a/src/distribution/wishart.rs
+++ b/src/distribution/wishart.rs
@@ -22,33 +22,33 @@ fn mvdigamma(p: i64, a: f64) -> f64 {
 /// Implements the [Wishart distribution](http://en.wikipedia.org/wiki/Wishart_distribution)
 #[derive(Debug, Clone)]
 pub struct Wishart {
-    df: f64,
-    S: DMatrix<f64>,
+    freedom: f64,
+    scale: DMatrix<f64>,
     chol: Cholesky<f64, Dynamic>,
 }
 
 impl Wishart {
-    pub fn new(df: f64, S: DMatrix<f64>) -> Result<Self> {
-        if S.nrows() != S.ncols() {
+    pub fn new(freedom: f64, scale: DMatrix<f64>) -> Result<Self> {
+        if scale.nrows() != scale.ncols() {
             return Err(StatsError::BadParams);
         }
-        if df <= 0.0 || df.is_nan() {
-            return Err(StatsError::ArgMustBePositive("df must be positive"));
+        if freedom <= 0.0 || freedom.is_nan() {
+            return Err(StatsError::ArgMustBePositive("degree of freedom must be positive"));
         }
-        if df <= S.nrows() as f64 - 1.0 {
-            return Err(StatsError::ArgGt("df must be greater than p-1", df));
+        if freedom <= scale.nrows() as f64 - 1.0 {
+            return Err(StatsError::ArgGt("degree of freedom must be greater than p-1", freedom));
         }
 
-        match Cholesky::new(S.clone()) {
+        match Cholesky::new(scale.clone()) {
             None => Err(StatsError::BadParams),
             Some(chol) => {
-                Ok(Wishart { df, S, chol })
+                Ok(Wishart { freedom, scale, chol })
             }
         }
     }
 
     pub fn p(&self) -> usize {
-        self.S.nrows()
+        self.scale.nrows()
     }
 
     pub fn entropy(&self) -> Option<f64> {
@@ -56,50 +56,50 @@ impl Wishart {
         Some(
             (p + 1.0) / 2.0 * self.chol.determinant().ln()
                 + 0.5 * p * (p + 1.0) * LN_2
-                + mvlgamma(p as i64, self.df / 2.0)
-                - (self.df - p - 1.0) / 2.0 * mvdigamma(p as i64, self.df / 2.0)
-                + self.df * p / 2.0
+                + mvlgamma(p as i64, self.freedom / 2.0)
+                - (self.freedom - p - 1.0) / 2.0 * mvdigamma(p as i64, self.freedom / 2.0)
+                + self.freedom * p / 2.0
         )
     }
 }
 
 impl MeanN<DMatrix<f64>> for Wishart {
     fn mean(&self) -> Option<DMatrix<f64>> {
-        Some(self.df * &self.S)
+        Some(self.freedom * &self.scale)
     }
 }
 
 impl VarianceN<DMatrix<f64>> for Wishart {
     fn variance(&self) -> Option<DMatrix<f64>> {
-        Some(self.S.map_with_location(|i, j, x| {
-            self.df * (self.S[(i, i)] * self.S[(j, j)] + x.powi(2))
+        Some(self.scale.map_with_location(|i, j, x| {
+            self.freedom * (self.scale[(i, i)] * self.scale[(j, j)] + x.powi(2))
         }))
     }
 }
 
 impl Mode<DMatrix<f64>> for Wishart {
     fn mode(&self) -> DMatrix<f64> {
-        (self.df - self.p() as f64 - 1.0) * &self.S
+        (self.freedom - self.p() as f64 - 1.0) * &self.scale
     }
 }
 
 impl ::rand::distributions::Distribution<DMatrix<f64>> for Wishart {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> DMatrix<f64> {
         let p = self.p();
-        let mut A = DMatrix::zeros(p, p);
+        let mut a = DMatrix::zeros(p, p);
 
         for i in 0..p {
-            A[(i, i)] = ChiSquared::new(self.df - i as f64).unwrap().sample(rng);
+            a[(i, i)] = ChiSquared::new(self.freedom - i as f64).unwrap().sample(rng);
         }
 
         for i in 1..p {
             for j in 0..i {
-                A[(i, j)] = ziggurat::sample_std_normal(rng);
+                a[(i, j)] = ziggurat::sample_std_normal(rng);
             }
         }
 
-        let L = self.chol.l();
-        &L * &A * A.transpose() * L.transpose()
+        let l = self.chol.l();
+        &l * &a * a.transpose() * l.transpose()
     }
 }
 
@@ -107,25 +107,25 @@ impl Continuous<DMatrix<f64>, f64> for Wishart {
     fn pdf(&self, x: DMatrix<f64>) -> f64 {
         let p = self.p() as f64;
         let x_det = x.determinant();
-        let x_sol = self.chol.solve(&x);
+        let six = self.chol.solve(&x);
 
-        x_det.powf((self.df - p - 1.0) / 2.0)
-            * (-0.5 * x_sol.trace()).exp()
-            / (2.0f64).powf(self.df * p / 2.0)
-            / self.chol.determinant().powf(self.df / 2.0)
-            / mvgamma(p as i64, self.df / 2.0)
+        x_det.powf((self.freedom - p - 1.0) / 2.0)
+            * (-0.5 * six.trace()).exp()
+            / (2.0f64).powf(self.freedom * p / 2.0)
+            / self.chol.determinant().powf(self.freedom / 2.0)
+            / mvgamma(p as i64, self.freedom / 2.0)
     }
 
     fn ln_pdf(&self, x: DMatrix<f64>) -> f64 {
         let p = self.p() as f64;
         let x_lndet = x.determinant().ln();
-        let x_sol = self.chol.solve(&x);
+        let six = self.chol.solve(&x);
 
-        x_lndet * (self.df - p - 1.0) / 2.0
-            - 0.5 * x_sol.trace()
-            - LN_2 * (self.df * p / 2.0)
-            - self.chol.determinant().ln() * (self.df / 2.0)
-            - mvlgamma(p as i64, self.df / 2.0)
+        x_lndet * (self.freedom - p - 1.0) / 2.0
+            - 0.5 * six.trace()
+            - LN_2 * (self.freedom * p / 2.0)
+            - self.chol.determinant().ln() * (self.freedom / 2.0)
+            - mvlgamma(p as i64, self.freedom / 2.0)
     }
 }
 
@@ -138,39 +138,39 @@ mod tests {
     use rand::SeedableRng;
     use crate::distribution::Continuous;
     use crate::distribution::wishart::Wishart;
-    use crate::statistics::{MeanN, VarianceN};
+    use crate::statistics::{MeanN, Mode, VarianceN};
 
-    fn try_create(df: f64, S: DMatrix<f64>) -> Wishart
+    fn try_create(freedom: f64, scale: DMatrix<f64>) -> Wishart
     {
-        let w = Wishart::new(df, S);
+        let w = Wishart::new(freedom, scale);
         assert!(w.is_ok());
         w.unwrap()
     }
 
     fn test_almost<F>(
-        df: f64,
-        S: DMatrix<f64>,
+        freedom: f64,
+        scale: DMatrix<f64>,
         expected: f64,
         acc: f64,
         eval: F,
     ) where
         F: FnOnce(Wishart) -> f64,
     {
-        let mvn = try_create(df, S);
+        let mvn = try_create(freedom, scale);
         let x = eval(mvn);
         assert_almost_eq!(expected, x, acc);
     }
 
     fn test_almost_mat<F>(
-        df: f64,
-        S: DMatrix<f64>,
+        freedom: f64,
+        scale: DMatrix<f64>,
         expected: DMatrix<f64>,
         acc: f64,
         eval: F,
     ) where
         F: FnOnce(Wishart) -> DMatrix<f64>,
     {
-        let mvn = try_create(df, S);
+        let mvn = try_create(freedom, scale);
         let x = eval(mvn);
 
         for i in 0..x.nrows() {
@@ -178,6 +178,24 @@ mod tests {
                 assert_almost_eq!(expected[(i, j)], x[(i, j)], acc);
             }
         }
+    }
+
+    #[test]
+    fn test_mean() {
+        test_almost_mat(
+            2.0, DMatrix::from_row_slice(2, 2, &[1.0, 0.0, 0.0, 1.0]),
+            DMatrix::from_row_slice(2, 2, &[2.0, 0.0, 0.0, 2.0]),
+            1e-15, |w| w.mean().unwrap(),
+        );
+    }
+
+    #[test]
+    fn test_mode() {
+        test_almost_mat(
+            7.0, DMatrix::from_row_slice(2, 2, &[1.0, 0.0, 0.0, 1.0]),
+            DMatrix::from_row_slice(2, 2, &[4.0, 0.0, 0.0, 4.0]),
+            1e-15, |w| w.mode(),
+        );
     }
 
     #[test]
@@ -228,15 +246,6 @@ mod tests {
     }
 
     #[test]
-    fn test_mode() {
-        test_almost_mat(
-            2.0, DMatrix::from_row_slice(2, 2, &[1.0, 0.0, 0.0, 1.0]),
-            DMatrix::from_row_slice(2, 2, &[2.0, 0.0, 0.0, 2.0]),
-            1e-15, |w| w.mean().unwrap(),
-        );
-    }
-
-    #[test]
     fn test_pdf() {
         test_almost(
             2.0, DMatrix::from_row_slice(2, 2, &[1.0, 0.0, 0.0, 1.0]),
@@ -245,9 +254,10 @@ mod tests {
         );
         test_almost(
             2.0, DMatrix::from_row_slice(2, 2, &[1.0, 0.0, 0.0, 1.0]),
-            0.02927491576215958,
-            1e-15, |w| w.pdf(DMatrix::from_row_slice(2, 2, &[1.0, 0.0, 0.0, 1.0])),
+            -3.5310242469692907,
+            1e-15, |w| w.ln_pdf(DMatrix::from_row_slice(2, 2, &[1.0, 0.0, 0.0, 1.0])),
         );
+
         test_almost(
             3.0, DMatrix::from_row_slice(3, 3, &[
                 1.0143, 0.0000, 0.0000,
@@ -267,33 +277,26 @@ mod tests {
                 0.0000, 0.2034, 0.0000,
                 0.0000, 0.0000, 0.9495
             ]),
-            2.3729077174800438e-5,
-            1e-12, |w| w.pdf(DMatrix::from_row_slice(3, 3, &[
-                1.7121, 0.0000, 0.0000,
+            -3.561453889551996,
+            1e-12, |w| w.ln_pdf(DMatrix::from_row_slice(3, 3, &[
+                0.7121, 0.0000, 0.0000,
                 0.0000, 0.4010, 0.0000,
-                0.0000, 0.0000, 9.5627,
+                0.0000, 0.0000, 0.5627,
             ])),
         );
-    }
 
-    #[test]
-    fn test_ln_pdf() {
-        test_almost(
-            2.0, DMatrix::from_row_slice(2, 2, &[1.0, 0.0, 0.0, 1.0]),
-            -3.5310242469692907,
-            1e-15, |w| w.ln_pdf(DMatrix::from_row_slice(2, 2, &[1.0, 0.0, 0.0, 1.0])),
-        );
+
         test_almost(
             3.0, DMatrix::from_row_slice(3, 3, &[
                 1.0143, 0.0000, 0.0000,
                 0.0000, 0.2034, 0.0000,
                 0.0000, 0.0000, 0.9495
             ]),
-            -3.561453889551996,
-            1e-12, |w| w.ln_pdf(DMatrix::from_row_slice(3, 3, &[
-                0.7121, 0.0000, 0.0000,
+            2.3729077174800438e-5,
+            1e-12, |w| w.pdf(DMatrix::from_row_slice(3, 3, &[
+                1.7121, 0.0000, 0.0000,
                 0.0000, 0.4010, 0.0000,
-                0.0000, 0.0000, 0.5627,
+                0.0000, 0.0000, 9.5627,
             ])),
         );
         test_almost(
@@ -321,7 +324,7 @@ mod tests {
 
         let mut rng = StdRng::seed_from_u64(42);
 
-        for i in 0..100 {
+        for _ in 0..100 {
             let sample = w.sample(&mut rng);
             let l_prob = w.ln_pdf(sample);
             assert!(l_prob.is_finite());

--- a/src/function/gamma.rs
+++ b/src/function/gamma.rs
@@ -421,6 +421,24 @@ fn signum(x: f64) -> f64 {
     }
 }
 
+/// Computes the [multivariate gamma function](https://en.wikipedia.org/wiki/Multivariate_gamma_function).
+pub fn mvgamma(p: i64, a: f64) -> f64 {
+    let mut res = std::f64::consts::PI.powf((p * (p - 1)) as f64 / 4.0);
+    for ii in 1..=p {
+        res *= gamma(a + (1 - ii) as f64 / 2.0);
+    }
+    res
+}
+
+/// Computes the log [multivariate gamma function](https://en.wikipedia.org/wiki/Multivariate_gamma_function).
+pub fn mvlgamma(p: i64, a: f64) -> f64 {
+    let mut res = (p * (p - 1)) as f64 * consts::LN_PI / 4.0;
+    for ii in 1..=p {
+        res += ln_gamma(a + (1 - ii) as f64 / 2.0);
+    }
+    res
+}
+
 #[rustfmt::skip]
 #[cfg(test)]
 mod tests {
@@ -804,5 +822,15 @@ mod tests {
         assert_almost_eq!(super::inv_digamma(1.5061176684318004727268212432509309022911739973934097), 5.0, 1e-14);
         assert_almost_eq!(super::inv_digamma(1.6110931485817511237336268416044190359814435699427405), 5.5, 1e-14);
         assert_almost_eq!(super::inv_digamma(2.2622143570941481235561593642219403924532310597356171), 10.1, 1e-13);
+    }
+
+    #[test]
+    fn test_ln_mvlgamma() {
+        assert!(super::mvlgamma(2, f64::NAN).is_nan());
+        assert_almost_eq!(super::mvlgamma(0, 1.0), 0.0, 1e-12);
+        assert_almost_eq!(super::mvlgamma(2, 1.0), 1.1447298858494002, 1e-12);
+        assert_almost_eq!(super::mvlgamma(3, 1.5), 2.1686775340635553, 1e-12);
+        assert_almost_eq!(super::mvlgamma(3, 150.0 + 1.0e-12), 1794.2387481112528, 1e-12);
+        assert_almost_eq!(super::mvlgamma(11, 14.5), 225.2071467353132, 1e-12);
     }
 }


### PR DESCRIPTION
This pr adds `Wishart` and `InverseWishart` distributions along with multivariate gamma functions `mvgamma` and `mvlgamma`.

mathnet implementations were used as a reference: [Wishart](https://github.com/mathnet/mathnet-numerics/blob/4b13ff4a5e7014997075df34a84d61f10bdd27b3/src/Numerics/Distributions/Wishart.cs) and [Inverse Wishart](https://github.com/mathnet/mathnet-numerics/blob/4b13ff4a5e7014997075df34a84d61f10bdd27b3/src/Numerics/Distributions/InverseWishart.cs)
The [Distributions.jl](https://github.com/JuliaStats/Distributions.jl) Julia package was used to create the testcases and as a cross-reference.

Thanks
