### PR TITLE
Mention quantile function in docstring

### DIFF
--- a/src/distribution/normal.rs
+++ b/src/distribution/normal.rs
@@ -100,7 +100,8 @@ impl ContinuousCDF<f64, f64> for Normal {
     }
 
     /// Calculates the inverse cumulative distribution function for the
-    /// normal distribution at `x`
+    /// normal distribution at `x`.
+    /// In other languages, such as R, this is known as the the quantile function.
     ///
     /// # Panics
     ///


### PR DESCRIPTION
First, of all, thanks for making and maintaining this project. I'm trying to make a wasm project and I would have probably given up without `statrs`.

Anyway, I'm always confused by the many synonyms used in statistics. This PR suggests to add one synonym to the `inverse_cdf` to the docstring of the normal distribution. This should make it at least visible when searching the docs?

Adding the note to all `inverse_cdf` implementations seems a bit redundant so that's why I kept it to the Normal for now.