### PR TITLE
Use nalgebra structs for constructing multivariate dist

### DIFF
--- a/src/distribution/multivariate_normal.rs
+++ b/src/distribution/multivariate_normal.rs
@@ -37,7 +37,7 @@ pub struct MultivariateNormal {
 }
 
 impl MultivariateNormal {
-    ///  Constructs a new multivariate normal distribution with a mean of `mean`
+    /// Constructs a new multivariate normal distribution with a mean of `mean`
     /// and covariance matrix `cov`
     ///
     /// # Errors
@@ -47,6 +47,18 @@ impl MultivariateNormal {
     pub fn new(mean: Vec<f64>, cov: Vec<f64>) -> Result<Self> {
         let mean = DVector::from_vec(mean);
         let cov = DMatrix::from_vec(mean.len(), mean.len(), cov);
+        return MultivariateNormal::new_from_nalgebra(mean, cov)
+    }
+
+    /// Constructs a new multivariate normal distribution with a mean of `mean`
+    /// and covariance matrix `cov`, but with explicitly using nalgebras
+    /// DVector and DMatrix instead of Vec<f64>
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the given covariance matrix is not
+    /// symmetric or positive-definite
+    pub fn new_from_nalgebra(mean: DVector<f64>, cov: DMatrix<f64>) -> Result<Self> {
         let dim = mean.len();
         // Check that the provided covariance matrix is symmetric
         if cov.lower_triangle() != cov.upper_triangle().transpose()
@@ -79,6 +91,7 @@ impl MultivariateNormal {
             }
         }
     }
+
     /// Returns the entropy of the multivariate normal distribution
     ///
     /// # Formula


### PR DESCRIPTION
Implementation of #168,
Move the checks from `new` to `new_from_nalgebra` and call `new_from_nalgebra` from `new` after converting to DVector/DMatrix