### PR TITLE
Add default implementation of survival functions

### DIFF
--- a/src/distribution/mod.rs
+++ b/src/distribution/mod.rs
@@ -101,7 +101,9 @@ pub trait ContinuousCDF<K: Float, T: Float>: Min<K> + Max<K> {
     /// let n = Uniform::new(0.0, 1.0).unwrap();
     /// assert_eq!(0.5, n.sf(0.5));
     /// ```
-    fn sf(&self, x: K) -> T;
+    fn sf(&self, x: K) -> T {
+        T::one() - self.cdf(x)
+    }
 
     /// Due to issues with rounding and floating-point accuracy the default
     /// implementation may be ill-behaved.
@@ -167,7 +169,9 @@ pub trait DiscreteCDF<K: Bounded + Clone + Num, T: Float>: Min<K> + Max<K> {
     /// let n = DiscreteUniform::new(1, 10).unwrap();
     /// assert_eq!(0.4, n.sf(6));
     /// ```
-    fn sf(&self, x: K) -> T;
+    fn sf(&self, x: K) -> T {
+        T::one() - self.cdf(x)
+    }
 
     /// Due to issues with rounding and floating-point accuracy the default implementation may be ill-behaved
     /// Specialized inverse cdfs should be used whenever possible.


### PR DESCRIPTION
Adds a default implementation of survival functions as $1-cdf(x)$ with
generics, which is 
```
T::one() - self.cdf(x)
```