### PR TITLE
Fix: Exponential distribution inverse CDF accuracy & performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@
 #editor specific
 /.vscode/
 .idea/
+*.iml
+
+# macOS
+.DS_Store

--- a/src/distribution/exponential.rs
+++ b/src/distribution/exponential.rs
@@ -120,7 +120,7 @@ impl ContinuousCDF<f64, f64> for Exp {
     ///
     /// where `p` is the probability and `λ` is the rate
     fn inverse_cdf(&self, p: f64) -> f64 {
-        -(1.0 - p).ln() / self.rate
+        -(-p).ln_1p() / self.rate
     }
 }
 

--- a/src/distribution/exponential.rs
+++ b/src/distribution/exponential.rs
@@ -109,6 +109,19 @@ impl ContinuousCDF<f64, f64> for Exp {
             (-self.rate * x).exp()
         }
     }
+
+    /// Calculates the inverse cumulative distribution function.
+    ///
+    /// # Formula
+    ///
+    /// ```ignore
+    /// -ln(1 - p) / λ
+    /// ```
+    ///
+    /// where `p` is the probability and `λ` is the rate
+    fn inverse_cdf(&self, p: f64) -> f64 {
+        -(1.0 - p).ln() / self.rate
+    }
 }
 
 impl Min<f64> for Exp {
@@ -455,6 +468,27 @@ mod tests {
         test_case(1.0, 1.0, cdf(f64::INFINITY));
         test_case(10.0, 1.0, cdf(f64::INFINITY));
         test_case(f64::INFINITY, 1.0, cdf(f64::INFINITY));
+    }
+
+    #[test]
+    fn test_inverse_cdf() {
+        let distribution = Exp::new(0.42).unwrap();
+        assert_eq!(distribution.median(), distribution.inverse_cdf(0.5));
+
+        let distribution = Exp::new(0.042).unwrap();
+        assert_eq!(distribution.median(), distribution.inverse_cdf(0.5));
+
+        let distribution = Exp::new(0.0042).unwrap();
+        assert_eq!(distribution.median(), distribution.inverse_cdf(0.5));
+
+        let distribution = Exp::new(0.33).unwrap();
+        assert_eq!(distribution.median(), distribution.inverse_cdf(0.5));
+
+        let distribution = Exp::new(0.033).unwrap();
+        assert_eq!(distribution.median(), distribution.inverse_cdf(0.5));
+
+        let distribution = Exp::new(0.0033).unwrap();
+        assert_eq!(distribution.median(), distribution.inverse_cdf(0.5));
     }
 
     #[test]


### PR DESCRIPTION
Hello,

While working on my project, I found that this function is calculated with a rather large margin of error. So, I had replaced the generic implementation with the [specific one](https://en.wikipedia.org/wiki/Exponential_distribution#Quantiles). If you comment out my implementation of the trait method, you will see what I am talking about from the test errors.

Also have find a bit weird behaviour of `cargo test` command when it simply ignores my tests, and probably some other tests too.

BR,
.