### PR TITLE
Remove lazy-static and make FCACHE a proper const

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ rand = "0.8"
 nalgebra = { version = "0.29", features = ["rand"] }
 approx = "0.5.0"
 num-traits = "0.2.14"
-lazy_static = "1.4.0"
 
 [dev-dependencies]
 criterion = "0.3.3"

--- a/src/function/factorial.rs
+++ b/src/function/factorial.rs
@@ -91,25 +91,33 @@ pub fn checked_multinomial(n: u64, ni: &[u64]) -> Result<f64> {
 
 // Initialization for pre-computed cache of 171 factorial
 // values 0!...170!
-lazy_static! {
-    static ref FCACHE: [f64; MAX_FACTORIAL + 1] = {
-        let mut fcache = [1.0; MAX_FACTORIAL + 1];
-        fcache
-            .iter_mut()
-            .enumerate()
-            .skip(1)
-            .fold(1.0, |acc, (i, elt)| {
-                let fac = acc * i as f64;
-                *elt = fac;
-                fac
-            });
-        fcache
-    };
-}
+const FCACHE: [f64; MAX_FACTORIAL + 1] = {
+    let mut fcache = [1.0; MAX_FACTORIAL + 1];
+
+    // `const` only allow while loops
+    let mut i = 1;
+    while i < MAX_FACTORIAL + 1 {
+        fcache[i] = fcache[i - 1] * i as f64;
+        i += 1;
+    }
+
+    fcache
+};
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_fcache() {
+        assert!((FCACHE[0] - 1.0).abs() < f64::EPSILON);
+        assert!((FCACHE[1] - 1.0).abs() < f64::EPSILON);
+        assert!((FCACHE[2] - 2.0).abs() < f64::EPSILON);
+        assert!((FCACHE[3] - 6.0).abs() < f64::EPSILON);
+        assert!((FCACHE[4] - 24.0).abs() < f64::EPSILON);
+        assert!((FCACHE[70] - 1197857166996989e85).abs() < f64::EPSILON);
+        assert!((FCACHE[170] - 7257415615307994e291).abs() < f64::EPSILON);
+    }
 
     #[test]
     fn test_factorial_and_ln_factorial() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,9 +35,6 @@
 #[macro_use]
 extern crate approx;
 
-#[macro_use]
-extern crate lazy_static;
-
 #[macro_export]
 macro_rules! assert_almost_eq {
     ($a:expr, $b:expr, $prec:expr) => {


### PR DESCRIPTION
This minor change removes the `lazy_static` dependency by making the `FCACHE` a `const`.