### PR TITLE
fix: mode for gamma distribution is 0 for shape<=1

### DIFF
--- a/src/distribution/gamma.rs
+++ b/src/distribution/gamma.rs
@@ -283,12 +283,16 @@ impl Mode<Option<f64>> for Gamma {
     /// # Formula
     ///
     /// ```text
-    /// (α - 1) / β
+    /// (α - 1) / β, where α≥1
     /// ```
     ///
     /// where `α` is the shape and `β` is the rate
     fn mode(&self) -> Option<f64> {
-        Some((self.shape - 1.0) / self.rate)
+        if self.shape < 1.0 {
+            None
+        } else {
+            Some((self.shape - 1.0) / self.rate)
+        }
     }
 }
 


### PR DESCRIPTION
addresses #210, opt for mode at singular point of x=0 in lieu of None.