### PR TITLE
Use `include` in Cargo.toml to remove some files from crates.io package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ homepage = "https://github.com/boxtown/statrs"
 repository = "https://github.com/boxtown/statrs"
 edition = "2018"
 
+include = ["CHANGELOG.md", "LICENSE.md", "src/"]
+
 [lib]
 name = "statrs"
 path = "src/lib.rs"


### PR DESCRIPTION
`cargo package --list` shows the contents that would be included in a crate file (e.g. when running `cargo publish`), and by diffing master vs PR it shows that the following files are no longer included in the package:

```
.github/workflows/test.yml
.gitignore
benches/order_statistics.rs
codecov.yml
data/nist/lew.txt
data/nist/lottery.txt
data/nist/mavro.txt
data/nist/michaelso.txt
data/nist/numacc1.txt
data/nist/numacc2.txt
data/nist/numacc3.txt
data/nist/numacc4.txt
rustfmt.toml
```

I think all of these except maybe the benchmark are pretty obvious to remove from the distributable package. Even if the NIST data is removed from the repo entirely (see #195), I'd argue it makes sense to use an allowlist for the distributable package instead of including everything by default.