### PR TITLE
Make `rustfmt` happy

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -12,9 +12,6 @@ use_small_heuristics = "Default"
 # TODO: single line functions only where short, please?
 # https://github.com/rust-lang/rustfmt/issues/3358
 fn_single_line = false
-fn_params_layout = "Compressed"
-overflow_delimited_expr = true
-where_single_line = true
 
 # enum_discrim_align_threshold = 20
 # struct_field_align_threshold = 20
@@ -23,7 +20,6 @@ where_single_line = true
 edition = "2021"
 
 # Misc:
-inline_attribute_width = 80
 blank_lines_upper_bound = 2
 reorder_impl_items = true
 # report_todo = "Unnumbered"

--- a/src/distribution/bernoulli.rs
+++ b/src/distribution/bernoulli.rs
@@ -101,7 +101,7 @@ impl DiscreteCDF<u64, f64> for Bernoulli {
         self.b.cdf(x)
     }
 
-    /// Calculates the survival function for the 
+    /// Calculates the survival function for the
     /// bernoulli distribution at `x`.
     ///
     /// # Formula
@@ -158,6 +158,7 @@ impl Distribution<f64> for Bernoulli {
     fn mean(&self) -> Option<f64> {
         self.b.mean()
     }
+
     /// Returns the variance of the bernoulli
     /// distribution
     ///
@@ -169,6 +170,7 @@ impl Distribution<f64> for Bernoulli {
     fn variance(&self) -> Option<f64> {
         self.b.variance()
     }
+
     /// Returns the entropy of the bernoulli
     /// distribution
     ///
@@ -181,6 +183,7 @@ impl Distribution<f64> for Bernoulli {
     fn entropy(&self) -> Option<f64> {
         self.b.entropy()
     }
+
     /// Returns the skewness of the bernoulli
     /// distribution
     ///

--- a/src/distribution/beta.rs
+++ b/src/distribution/beta.rs
@@ -155,7 +155,7 @@ impl ContinuousCDF<f64, f64> for Beta {
         } else if ulps_eq!(self.shape_a, 1.0) && ulps_eq!(self.shape_b, 1.0) {
             1. - x
         } else {
-            beta::beta_reg(self.shape_b, self.shape_a, 1.0 - x) 
+            beta::beta_reg(self.shape_b, self.shape_a, 1.0 - x)
         }
     }
 }
@@ -208,6 +208,7 @@ impl Distribution<f64> for Beta {
         };
         Some(mean)
     }
+
     /// Returns the variance of the beta distribution
     ///
     /// # Remarks
@@ -230,6 +231,7 @@ impl Distribution<f64> for Beta {
         };
         Some(var)
     }
+
     /// Returns the entropy of the beta distribution
     ///
     /// # Formula
@@ -251,6 +253,7 @@ impl Distribution<f64> for Beta {
         };
         Some(entr)
     }
+
     /// Returns the skewness of the Beta distribution
     ///
     /// # Formula

--- a/src/distribution/binomial.rs
+++ b/src/distribution/binomial.rs
@@ -181,6 +181,7 @@ impl Distribution<f64> for Binomial {
     fn mean(&self) -> Option<f64> {
         Some(self.p * self.n as f64)
     }
+
     /// Returns the variance of the binomial distribution
     ///
     /// # Formula
@@ -191,6 +192,7 @@ impl Distribution<f64> for Binomial {
     fn variance(&self) -> Option<f64> {
         Some(self.p * (1.0 - self.p) * self.n as f64)
     }
+
     /// Returns the entropy of the binomial distribution
     ///
     /// # Formula
@@ -209,6 +211,7 @@ impl Distribution<f64> for Binomial {
         };
         Some(entr)
     }
+
     /// Returns the skewness of the binomial distribution
     ///
     /// # Formula

--- a/src/distribution/categorical.rs
+++ b/src/distribution/categorical.rs
@@ -12,7 +12,7 @@ use std::f64;
 /// # Examples
 ///
 /// ```
-///
+/// 
 /// use statrs::distribution::{Categorical, Discrete};
 /// use statrs::statistics::Distribution;
 /// use statrs::prec;
@@ -25,7 +25,7 @@ use std::f64;
 pub struct Categorical {
     norm_pmf: Vec<f64>,
     cdf: Vec<f64>,
-    sf: Vec<f64>
+    sf: Vec<f64>,
 }
 
 impl Categorical {
@@ -194,6 +194,7 @@ impl Distribution<f64> for Categorical {
                 .fold(0.0, |acc, (idx, &val)| acc + idx as f64 * val),
         )
     }
+
     /// Returns the variance of the categorical distribution
     ///
     /// # Formula
@@ -217,6 +218,7 @@ impl Distribution<f64> for Categorical {
             });
         Some(var)
     }
+
     /// Returns the entropy of the categorical distribution
     ///
     /// # Formula
@@ -294,7 +296,7 @@ pub fn prob_mass_to_cdf(prob_mass: &[f64]) -> Vec<f64> {
     cdf
 }
 
-/// Computes the sf from the given cumulative densities. 
+/// Computes the sf from the given cumulative densities.
 /// Performs no parameter or bounds checking.
 pub fn cdf_to_sf(cdf: &[f64]) -> Vec<f64> {
     let max = *cdf.last().unwrap();

--- a/src/distribution/chi.rs
+++ b/src/distribution/chi.rs
@@ -185,6 +185,7 @@ impl Distribution<f64> for Chi {
             Some(mean)
         }
     }
+
     /// Returns the variance of the chi distribution
     ///
     /// # Remarks
@@ -203,6 +204,7 @@ impl Distribution<f64> for Chi {
         let mean = self.mean()?;
         Some(self.freedom - mean * mean)
     }
+
     /// Returns the entropy of the chi distribution
     ///
     /// # Remarks
@@ -228,6 +230,7 @@ impl Distribution<f64> for Chi {
                 / 2.0;
         Some(entr)
     }
+
     /// Returns the skewness of the chi distribution
     ///
     /// # Remarks

--- a/src/distribution/chi_squared.rs
+++ b/src/distribution/chi_squared.rs
@@ -177,6 +177,7 @@ impl Distribution<f64> for ChiSquared {
     fn mean(&self) -> Option<f64> {
         self.g.mean()
     }
+
     /// Returns the variance of the chi-squared distribution
     ///
     /// # Formula
@@ -189,6 +190,7 @@ impl Distribution<f64> for ChiSquared {
     fn variance(&self) -> Option<f64> {
         self.g.variance()
     }
+
     /// Returns the entropy of the chi-squared distribution
     ///
     /// # Formula
@@ -202,6 +204,7 @@ impl Distribution<f64> for ChiSquared {
     fn entropy(&self) -> Option<f64> {
         self.g.entropy()
     }
+
     /// Returns the skewness of the chi-squared distribution
     ///
     /// # Formula

--- a/src/distribution/dirac.rs
+++ b/src/distribution/dirac.rs
@@ -56,7 +56,6 @@ impl ContinuousCDF<f64, f64> for Dirac {
     /// dirac distribution at `x`
     ///
     /// Where the value is 1 if x > `v`, 0 otherwise.
-    ///
     fn cdf(&self, x: f64) -> f64 {
         if x < self.0 {
             0.0
@@ -69,7 +68,6 @@ impl ContinuousCDF<f64, f64> for Dirac {
     /// dirac distribution at `x`
     ///
     /// Where the value is 0 if x > `v`, 1 otherwise.
-    ///
     fn sf(&self, x: f64) -> f64 {
         if x < self.0 {
             1.0
@@ -117,6 +115,7 @@ impl Distribution<f64> for Dirac {
     fn mean(&self) -> Option<f64> {
         Some(self.0)
     }
+
     /// Returns the variance of the dirac distribution
     ///
     /// # Formula
@@ -129,6 +128,7 @@ impl Distribution<f64> for Dirac {
     fn variance(&self) -> Option<f64> {
         Some(0.0)
     }
+
     /// Returns the entropy of the dirac distribution
     ///
     /// # Formula
@@ -141,6 +141,7 @@ impl Distribution<f64> for Dirac {
     fn entropy(&self) -> Option<f64> {
         Some(0.0)
     }
+
     /// Returns the skewness of the dirac distribution
     ///
     /// # Formula

--- a/src/distribution/dirichlet.rs
+++ b/src/distribution/dirichlet.rs
@@ -107,6 +107,7 @@ impl Dirichlet {
     fn alpha_sum(&self) -> f64 {
         self.alpha.fold(0.0, |acc, x| acc + x)
     }
+
     /// Returns the entropy of the dirichlet distribution
     ///
     /// # Formula

--- a/src/distribution/discrete_uniform.rs
+++ b/src/distribution/discrete_uniform.rs
@@ -84,7 +84,7 @@ impl DiscreteCDF<i64, f64> for DiscreteUniform {
     }
 
     fn sf(&self, x: i64) -> f64 {
-        //1. - self.cdf(x)
+        // 1. - self.cdf(x)
         if x < self.min {
             1.0
         } else if x >= self.max {
@@ -137,6 +137,7 @@ impl Distribution<f64> for DiscreteUniform {
     fn mean(&self) -> Option<f64> {
         Some((self.min + self.max) as f64 / 2.0)
     }
+
     /// Returns the variance of the discrete uniform distribution
     ///
     /// # Formula
@@ -148,6 +149,7 @@ impl Distribution<f64> for DiscreteUniform {
         let diff = (self.max - self.min) as f64;
         Some(((diff + 1.0) * (diff + 1.0) - 1.0) / 12.0)
     }
+
     /// Returns the entropy of the discrete uniform distribution
     ///
     /// # Formula
@@ -159,6 +161,7 @@ impl Distribution<f64> for DiscreteUniform {
         let diff = (self.max - self.min) as f64;
         Some((diff + 1.0).ln())
     }
+
     /// Returns the skewness of the discrete uniform distribution
     ///
     /// # Formula

--- a/src/distribution/empirical.rs
+++ b/src/distribution/empirical.rs
@@ -56,7 +56,6 @@ impl Empirical {
     ///
     /// let mut result = Empirical::new();
     /// assert!(result.is_ok());
-    ///
     /// ```
     pub fn new() -> Result<Empirical> {
         Ok(Empirical {
@@ -65,6 +64,7 @@ impl Empirical {
             data: BTreeMap::new(),
         })
     }
+
     pub fn from_vec(src: Vec<f64>) -> Empirical {
         let mut empirical = Empirical::new().unwrap();
         for elt in src.into_iter() {
@@ -72,6 +72,7 @@ impl Empirical {
         }
         empirical
     }
+
     pub fn add(&mut self, data_point: f64) {
         if !data_point.is_nan() {
             self.sum += 1.;
@@ -89,6 +90,7 @@ impl Empirical {
             *self.data.entry(NonNan(data_point)).or_insert(0) += 1;
         }
     }
+
     pub fn remove(&mut self, data_point: f64) {
         if !data_point.is_nan() {
             if let (Some(val), Some((mean, var))) =
@@ -111,6 +113,7 @@ impl Empirical {
             }
         }
     }
+
     // Due to issues with rounding and floating-point accuracy the default
     // implementation may be ill-behaved.
     // Specialized inverse cdfs should be used whenever possible.
@@ -158,7 +161,7 @@ impl ::rand::distributions::Distribution<f64> for Empirical {
 /// Panics if number of samples is zero
 impl Max<f64> for Empirical {
     fn max(&self) -> f64 {
-        self.data.keys().rev().map(|key| key.0) .next().unwrap()
+        self.data.keys().rev().map(|key| key.0).next().unwrap()
     }
 }
 
@@ -173,6 +176,7 @@ impl Distribution<f64> for Empirical {
     fn mean(&self) -> Option<f64> {
         self.mean_and_var.map(|(mean, _)| mean)
     }
+
     fn variance(&self) -> Option<f64> {
         self.mean_and_var.map(|(_, var)| var / (self.sum - 1.))
     }
@@ -256,8 +260,8 @@ mod tests {
         let unchanged = empirical.clone();
         empirical.add(2.0);
         empirical.remove(2.0);
-         //because of rounding errors, this doesn't hold in general
-         //due to the mean and variance being calculated in a streaming way
+        // because of rounding errors, this doesn't hold in general
+        // due to the mean and variance being calculated in a streaming way
         assert_eq!(unchanged, empirical);
     }
 }

--- a/src/distribution/erlang.rs
+++ b/src/distribution/erlang.rs
@@ -166,6 +166,7 @@ impl Distribution<f64> for Erlang {
     fn mean(&self) -> Option<f64> {
         self.g.mean()
     }
+
     /// Returns the variance of the erlang distribution
     ///
     /// # Formula
@@ -178,6 +179,7 @@ impl Distribution<f64> for Erlang {
     fn variance(&self) -> Option<f64> {
         self.g.variance()
     }
+
     /// Returns the entropy of the erlang distribution
     ///
     /// # Formula
@@ -191,6 +193,7 @@ impl Distribution<f64> for Erlang {
     fn entropy(&self) -> Option<f64> {
         self.g.entropy()
     }
+
     /// Returns the skewness of the erlang distribution
     ///
     /// # Formula

--- a/src/distribution/exponential.rs
+++ b/src/distribution/exponential.rs
@@ -152,6 +152,7 @@ impl Distribution<f64> for Exp {
     fn mean(&self) -> Option<f64> {
         Some(1.0 / self.rate)
     }
+
     /// Returns the variance of the exponential distribution
     ///
     /// # Formula
@@ -164,6 +165,7 @@ impl Distribution<f64> for Exp {
     fn variance(&self) -> Option<f64> {
         Some(1.0 / (self.rate * self.rate))
     }
+
     /// Returns the entropy of the exponential distribution
     ///
     /// # Formula
@@ -176,6 +178,7 @@ impl Distribution<f64> for Exp {
     fn entropy(&self) -> Option<f64> {
         Some(1.0 - self.rate.ln())
     }
+
     /// Returns the skewness of the exponential distribution
     ///
     /// # Formula

--- a/src/distribution/fisher_snedecor.rs
+++ b/src/distribution/fisher_snedecor.rs
@@ -144,8 +144,8 @@ impl ContinuousCDF<f64, f64> for FisherSnedecor {
         } else {
             beta::beta_reg(
                 self.freedom_2 / 2.0,
-                self.freedom_1 / 2.0, 
-                1. - ((self.freedom_1 * x) / (self.freedom_1 * x + self.freedom_2))
+                self.freedom_1 / 2.0,
+                1. - ((self.freedom_1 * x) / (self.freedom_1 * x + self.freedom_2)),
             )
         }
     }
@@ -206,6 +206,7 @@ impl Distribution<f64> for FisherSnedecor {
             Some(self.freedom_2 / (self.freedom_2 - 2.0))
         }
     }
+
     /// Returns the variance of the fisher-snedecor distribution
     ///
     /// # Panics
@@ -237,6 +238,7 @@ impl Distribution<f64> for FisherSnedecor {
             Some(val)
         }
     }
+
     /// Returns the skewness of the fisher-snedecor distribution
     ///
     /// # Panics

--- a/src/distribution/gamma.rs
+++ b/src/distribution/gamma.rs
@@ -455,7 +455,11 @@ mod tests {
         for &(arg, res) in test.iter() {
             test_case_special(arg, res, 10e-6, f);
         }
-        let test = [((10.0, 10.0), 0.9), ((10.0, 1.0), 9.0), ((10.0, f64::INFINITY), 0.0)];
+        let test = [
+            ((10.0, 10.0), 0.9),
+            ((10.0, 1.0), 9.0),
+            ((10.0, f64::INFINITY), 0.0),
+        ];
         for &(arg, res) in test.iter() {
             test_case(arg, res, f);
         }

--- a/src/distribution/gamma.rs
+++ b/src/distribution/gamma.rs
@@ -132,17 +132,13 @@ impl ContinuousCDF<f64, f64> for Gamma {
     fn sf(&self, x: f64) -> f64 {
         if x <= 0.0 {
             1.0
-        }
-        else if ulps_eq!(x, self.shape) && self.rate.is_infinite() {
+        } else if ulps_eq!(x, self.shape) && self.rate.is_infinite() {
             0.0
-        }
-        else if self.rate.is_infinite() {
+        } else if self.rate.is_infinite() {
             1.0
-        }
-        else if x.is_infinite() {
+        } else if x.is_infinite() {
             0.0
-        }
-        else {
+        } else {
             gamma::gamma_ur(self.shape, x * self.rate)
         }
     }

--- a/src/distribution/gamma.rs
+++ b/src/distribution/gamma.rs
@@ -191,6 +191,7 @@ impl Distribution<f64> for Gamma {
     fn mean(&self) -> Option<f64> {
         Some(self.shape / self.rate)
     }
+
     /// Returns the variance of the gamma distribution
     ///
     /// # Formula
@@ -203,6 +204,7 @@ impl Distribution<f64> for Gamma {
     fn variance(&self) -> Option<f64> {
         Some(self.shape / (self.rate * self.rate))
     }
+
     /// Returns the entropy of the gamma distribution
     ///
     /// # Formula
@@ -219,6 +221,7 @@ impl Distribution<f64> for Gamma {
             + (1.0 - self.shape) * gamma::digamma(self.shape);
         Some(entr)
     }
+
     /// Returns the skewness of the gamma distribution
     ///
     /// # Formula
@@ -504,9 +507,9 @@ mod tests {
         for &(arg, x, res) in test.iter() {
             test_case(arg, res, f(x));
         }
-        //TODO: test special
+        // TODO: test special
         // test_is_nan((10.0, f64::INFINITY), pdf(1.0)); // is this really the behavior we want?
-        //TODO: test special
+        // TODO: test special
         // (10.0, f64::INFINITY, f64::INFINITY, 0.0, pdf(f64::INFINITY)),];
     }
 

--- a/src/distribution/geometric.rs
+++ b/src/distribution/geometric.rs
@@ -159,6 +159,7 @@ impl Distribution<f64> for Geometric {
     fn mean(&self) -> Option<f64> {
         Some(1.0 / self.p)
     }
+
     /// Returns the standard deviation of the geometric distribution
     ///
     /// # Formula
@@ -169,6 +170,7 @@ impl Distribution<f64> for Geometric {
     fn variance(&self) -> Option<f64> {
         Some((1.0 - self.p) / (self.p * self.p))
     }
+
     /// Returns the entropy of the geometric distribution
     ///
     /// # Formula
@@ -180,6 +182,7 @@ impl Distribution<f64> for Geometric {
         let inv = 1.0 / self.p;
         Some(-inv * (1. - self.p).log(2.0) + (inv - 1.).log(2.0))
     }
+
     /// Returns the skewness of the geometric distribution
     ///
     /// # Formula

--- a/src/distribution/hypergeometric.rs
+++ b/src/distribution/hypergeometric.rs
@@ -258,6 +258,7 @@ impl Distribution<f64> for Hypergeometric {
             Some(self.successes as f64 * self.draws as f64 / self.population as f64)
         }
     }
+
     /// Returns the variance of the hypergeometric distribution
     ///
     /// # None
@@ -281,6 +282,7 @@ impl Distribution<f64> for Hypergeometric {
             Some(val)
         }
     }
+
     /// Returns the skewness of the hypergeometric distribution
     ///
     /// # None

--- a/src/distribution/inverse_gamma.rs
+++ b/src/distribution/inverse_gamma.rs
@@ -190,6 +190,7 @@ impl Distribution<f64> for InverseGamma {
             Some(self.rate / (self.shape - 1.0))
         }
     }
+
     /// Returns the variance of the inverse gamma distribution
     ///
     /// # None
@@ -212,6 +213,7 @@ impl Distribution<f64> for InverseGamma {
             Some(val)
         }
     }
+
     /// Returns the entropy of the inverse gamma distribution
     ///
     /// # Formula
@@ -227,6 +229,7 @@ impl Distribution<f64> for InverseGamma {
             - (1.0 + self.shape) * gamma::digamma(self.shape);
         Some(entr)
     }
+
     /// Returns the skewness of the inverse gamma distribution
     ///
     /// # None

--- a/src/distribution/laplace.rs
+++ b/src/distribution/laplace.rs
@@ -389,7 +389,13 @@ mod tests {
     #[test]
     fn test_entropy() {
         let entropy = |x: Laplace| x.entropy().unwrap();
-        test_almost(f64::NEG_INFINITY, 0.1, (2.0 * f64::consts::E * 0.1).ln(), 1E-12, entropy);
+        test_almost(
+            f64::NEG_INFINITY,
+            0.1,
+            (2.0 * f64::consts::E * 0.1).ln(),
+            1E-12,
+            entropy,
+        );
         test_almost(-6.0, 1.0, (2.0 * f64::consts::E).ln(), 1E-12, entropy);
         test_almost(1.0, 7.0, (2.0 * f64::consts::E * 7.0).ln(), 1E-12, entropy);
         test_almost(5., 10., (2. * f64::consts::E * 10.).ln(), 1E-12, entropy);

--- a/src/distribution/laplace.rs
+++ b/src/distribution/laplace.rs
@@ -193,6 +193,7 @@ impl Distribution<f64> for Laplace {
     fn mean(&self) -> Option<f64> {
         Some(self.location)
     }
+
     /// Returns the variance of the laplace distribution
     ///
     /// # Formula
@@ -205,6 +206,7 @@ impl Distribution<f64> for Laplace {
     fn variance(&self) -> Option<f64> {
         Some(2. * self.scale * self.scale)
     }
+
     /// Returns the entropy of the laplace distribution
     ///
     /// # Formula
@@ -217,6 +219,7 @@ impl Distribution<f64> for Laplace {
     fn entropy(&self) -> Option<f64> {
         Some((2. * self.scale).ln() + 1.)
     }
+
     /// Returns the skewness of the laplace distribution
     ///
     /// # Formula

--- a/src/distribution/log_normal.rs
+++ b/src/distribution/log_normal.rs
@@ -156,6 +156,7 @@ impl Distribution<f64> for LogNormal {
     fn mean(&self) -> Option<f64> {
         Some((self.location + self.scale * self.scale / 2.0).exp())
     }
+
     /// Returns the variance of the log-normal distribution
     ///
     /// # Formula
@@ -169,6 +170,7 @@ impl Distribution<f64> for LogNormal {
         let sigma2 = self.scale * self.scale;
         Some((sigma2.exp() - 1.0) * (self.location + self.location + sigma2).exp())
     }
+
     /// Returns the entropy of the log-normal distribution
     ///
     /// # Formula
@@ -181,6 +183,7 @@ impl Distribution<f64> for LogNormal {
     fn entropy(&self) -> Option<f64> {
         Some(0.5 + self.scale.ln() + self.location + consts::LN_SQRT_2PI)
     }
+
     /// Returns the skewness of the log-normal distribution
     ///
     /// # Formula

--- a/src/distribution/multivariate_normal.rs
+++ b/src/distribution/multivariate_normal.rs
@@ -205,6 +205,7 @@ impl<'a> Continuous<&'a DVector<f64>, f64> for MultivariateNormal {
                 .unwrap();
         self.pdf_const * exp_term.exp()
     }
+
     /// Calculates the log probability density function for the multivariate
     /// normal distribution at `x`. Equivalent to pdf(x).ln().
     fn ln_pdf(&self, x: &'a DVector<f64>) -> f64 {
@@ -232,6 +233,7 @@ impl Continuous<Vec<f64>, f64> for MultivariateNormal {
     fn pdf(&self, x: Vec<f64>) -> f64 {
         self.pdf(&DVector::from(x))
     }
+
     /// Calculates the log probability density function for the multivariate
     /// normal distribution at `x`. Equivalent to pdf(x).ln().
     fn ln_pdf(&self, x: Vec<f64>) -> f64 {

--- a/src/distribution/negative_binomial.rs
+++ b/src/distribution/negative_binomial.rs
@@ -188,6 +188,7 @@ impl DiscreteDistribution<f64> for NegativeBinomial {
     fn mean(&self) -> Option<f64> {
         Some(self.r * (1.0 - self.p) / self.p)
     }
+
     /// Returns the variance of the negative binomial distribution.
     ///
     /// # Formula
@@ -198,6 +199,7 @@ impl DiscreteDistribution<f64> for NegativeBinomial {
     fn variance(&self) -> Option<f64> {
         Some(self.r * (1.0 - self.p) / (self.p * self.p))
     }
+
     /// Returns the skewness of the negative binomial distribution.
     ///
     /// # Formula

--- a/src/distribution/normal.rs
+++ b/src/distribution/normal.rs
@@ -160,6 +160,7 @@ impl Distribution<f64> for Normal {
     fn mean(&self) -> Option<f64> {
         Some(self.mean)
     }
+
     /// Returns the variance of the normal distribution
     ///
     /// # Formula
@@ -172,6 +173,7 @@ impl Distribution<f64> for Normal {
     fn variance(&self) -> Option<f64> {
         Some(self.std_dev * self.std_dev)
     }
+
     /// Returns the entropy of the normal distribution
     ///
     /// # Formula
@@ -184,6 +186,7 @@ impl Distribution<f64> for Normal {
     fn entropy(&self) -> Option<f64> {
         Some(self.std_dev.ln() + consts::LN_SQRT_2PIE)
     }
+
     /// Returns the skewness of the normal distribution
     ///
     /// # Formula

--- a/src/distribution/pareto.rs
+++ b/src/distribution/pareto.rs
@@ -188,6 +188,7 @@ impl Distribution<f64> for Pareto {
             Some((self.shape * self.scale) / (self.shape - 1.0))
         }
     }
+
     /// Returns the variance of the Pareto distribution
     ///
     /// # Formula
@@ -209,6 +210,7 @@ impl Distribution<f64> for Pareto {
             Some(a * a * self.shape / (self.shape - 2.0))
         }
     }
+
     /// Returns the entropy for the Pareto distribution
     ///
     /// # Formula
@@ -221,6 +223,7 @@ impl Distribution<f64> for Pareto {
     fn entropy(&self) -> Option<f64> {
         Some(self.shape.ln() - self.scale.ln() - (1.0 / self.shape) - 1.0)
     }
+
     /// Returns the skewness of the Pareto distribution
     ///
     /// # Panics

--- a/src/distribution/poisson.rs
+++ b/src/distribution/poisson.rs
@@ -148,6 +148,7 @@ impl Distribution<f64> for Poisson {
     fn mean(&self) -> Option<f64> {
         Some(self.lambda)
     }
+
     /// Returns the variance of the poisson distribution
     ///
     /// # Formula
@@ -160,6 +161,7 @@ impl Distribution<f64> for Poisson {
     fn variance(&self) -> Option<f64> {
         Some(self.lambda)
     }
+
     /// Returns the entropy of the poisson distribution
     ///
     /// # Formula
@@ -177,6 +179,7 @@ impl Distribution<f64> for Poisson {
                 - 19.0 / (360.0 * self.lambda * self.lambda * self.lambda),
         )
     }
+
     /// Returns the skewness of the poisson distribution
     ///
     /// # Formula

--- a/src/distribution/students_t.rs
+++ b/src/distribution/students_t.rs
@@ -1098,7 +1098,7 @@ mod tests {
         //       for p in ps:
         //           q = t.invcdf(p, df)
         //           print(f"({p:5.3f}, {df:5.1f}, {float(q)}),")
-        //
+        #[rustfmt::skip]
         let invcdf_data = [
             // p       df    inverse_cdf(p, df)
             (0.001,   1.0, -318.30883898555044),

--- a/src/distribution/students_t.rs
+++ b/src/distribution/students_t.rs
@@ -252,6 +252,7 @@ impl Distribution<f64> for StudentsT {
             Some(self.location)
         }
     }
+
     /// Returns the variance of the student's t-distribution
     ///
     /// # None
@@ -280,6 +281,7 @@ impl Distribution<f64> for StudentsT {
             None
         }
     }
+
     /// Returns the entropy for the student's t-distribution
     ///
     /// # Formula
@@ -301,6 +303,7 @@ impl Distribution<f64> for StudentsT {
             + (self.freedom.sqrt() * beta::beta(self.freedom / 2.0, 0.5)).ln();
         Some(result + shift)
     }
+
     /// Returns the skewness of the student's t-distribution
     ///
     /// # None
@@ -597,7 +600,6 @@ mod tests {
         test_case((0.0, 1.0, f64::INFINITY), 0.841344746068543, cdf(1.0));
         test_case((0.0, 1.0, f64::INFINITY), 0.977249868051821, cdf(2.0));
     }
-
 
     #[test]
     fn test_sf() {

--- a/src/distribution/triangular.rs
+++ b/src/distribution/triangular.rs
@@ -165,6 +165,7 @@ impl Distribution<f64> for Triangular {
     fn mean(&self) -> Option<f64> {
         Some((self.min + self.max + self.mode) / 3.0)
     }
+
     /// Returns the variance of the triangular distribution
     ///
     /// # Formula
@@ -178,6 +179,7 @@ impl Distribution<f64> for Triangular {
         let c = self.mode;
         Some((a * a + b * b + c * c - a * b - a * c - b * c) / 18.0)
     }
+
     /// Returns the entropy of the triangular distribution
     ///
     /// # Formula
@@ -188,6 +190,7 @@ impl Distribution<f64> for Triangular {
     fn entropy(&self) -> Option<f64> {
         Some(0.5 + ((self.max - self.min) / 2.0).ln())
     }
+
     /// Returns the skewness of the triangular distribution
     ///
     /// # Formula

--- a/src/distribution/uniform.rs
+++ b/src/distribution/uniform.rs
@@ -140,6 +140,7 @@ impl Distribution<f64> for Uniform {
     fn mean(&self) -> Option<f64> {
         Some((self.min + self.max) / 2.0)
     }
+
     /// Returns the variance for the continuous uniform distribution
     ///
     /// # Formula
@@ -150,6 +151,7 @@ impl Distribution<f64> for Uniform {
     fn variance(&self) -> Option<f64> {
         Some((self.max - self.min) * (self.max - self.min) / 12.0)
     }
+
     /// Returns the entropy for the continuous uniform distribution
     ///
     /// # Formula
@@ -160,6 +162,7 @@ impl Distribution<f64> for Uniform {
     fn entropy(&self) -> Option<f64> {
         Some((self.max - self.min).ln())
     }
+
     /// Returns the skewness for the continuous uniform distribution
     ///
     /// # Formula

--- a/src/distribution/weibull.rs
+++ b/src/distribution/weibull.rs
@@ -177,6 +177,7 @@ impl Distribution<f64> for Weibull {
     fn mean(&self) -> Option<f64> {
         Some(self.scale * gamma::gamma(1.0 + 1.0 / self.shape))
     }
+
     /// Returns the variance of the weibull distribution
     ///
     /// # Formula
@@ -191,6 +192,7 @@ impl Distribution<f64> for Weibull {
         let mean = self.mean()?;
         Some(self.scale * self.scale * gamma::gamma(1.0 + 2.0 / self.shape) - mean * mean)
     }
+
     /// Returns the entropy of the weibull distribution
     ///
     /// # Formula
@@ -207,6 +209,7 @@ impl Distribution<f64> for Weibull {
             + 1.0;
         Some(entr)
     }
+
     /// Returns the skewness of the weibull distribution
     ///
     /// # Formula

--- a/src/function/beta.rs
+++ b/src/function/beta.rs
@@ -204,7 +204,6 @@ pub fn checked_beta_reg(a: f64, b: f64, x: f64) -> Result<f64> {
 }
 
 /// Computes the inverse of the regularized incomplete beta function
-//
 // This code is based on the implementation in the ["special"][1] crate,
 // which in turn is based on a [C implementation][2] by John Burkardt. The
 // original algorithm was published in Applied Statistics and is known as

--- a/src/statistics/slice_statistics.rs
+++ b/src/statistics/slice_statistics.rs
@@ -7,6 +7,7 @@ pub struct Data<D>(D);
 
 impl<D: AsRef<[f64]>> Index<usize> for Data<D> {
     type Output = f64;
+
     fn index(&self, i: usize) -> &f64 {
         &self.0.as_ref()[i]
     }
@@ -22,18 +23,23 @@ impl<D: AsMut<[f64]> + AsRef<[f64]>> Data<D> {
     pub fn new(data: D) -> Self {
         Data(data)
     }
+
     pub fn swap(&mut self, i: usize, j: usize) {
         self.0.as_mut().swap(i, j)
     }
+
     pub fn len(&self) -> usize {
         self.0.as_ref().len()
     }
+
     pub fn is_empty(&self) -> bool {
         self.0.as_ref().len() == 0
     }
+
     pub fn iter(&self) -> core::slice::Iter<'_, f64> {
         self.0.as_ref().iter()
     }
+
     // Selection algorithm from Numerical Recipes
     // See: https://en.wikipedia.org/wiki/Selection_algorithm
     fn select_inplace(&mut self, rank: usize) -> f64 {
@@ -299,6 +305,7 @@ impl<D: AsMut<[f64]> + AsRef<[f64]>> Distribution<f64> for Data<D> {
     fn mean(&self) -> Option<f64> {
         Some(Statistics::mean(self.iter()))
     }
+
     /// Estimates the unbiased population variance from the provided samples
     ///
     /// # Remarks


### PR DESCRIPTION
Most of this should be uncontroversial.

[Rustfmt page](https://rust-lang.github.io/rustfmt/?version=v1.6.0) (rules can be looked up here).

I've seen `fn_params_layout = "Compressed"` in other projects, but all the code in statrs already adhered to the other rule (`"Tall"`), so I don't see why this should be `"Compressed"`. Plus it only affects a few functions, so this wouldn't save many lines anyways.

All the other rules that I removed seem unconventional to me, and again, all code in statrs at the moment adheres to these rules being `false` or not set. So I don't see a reason to keep these.