### PR TITLE
Fix inverse_cdf for Gamma

### DIFF
--- a/src/distribution/gamma.rs
+++ b/src/distribution/gamma.rs
@@ -609,6 +609,25 @@ mod tests {
     }
 
     #[test]
+    fn test_cdf_inverse_identity() {
+        let f = |p: f64| move |g: Gamma| g.cdf(g.inverse_cdf(p));
+        let params = [
+            (1.0, 0.1),
+            (1.0, 1.0),
+            (10.0, 10.0),
+            (10.0, 1.0),
+            (100.0, 200.0),
+        ];
+
+        for param in params {
+            for n in -5..0 {
+                let p = 10.0f64.powi(n);
+                test_case(param, p, f(p));
+            }
+        }
+    }
+
+    #[test]
     fn test_sf() {
         let f = |arg: f64| move |x: Gamma| x.sf(arg);
         let test = [

--- a/src/distribution/gamma.rs
+++ b/src/distribution/gamma.rs
@@ -145,7 +145,6 @@ impl ContinuousCDF<f64, f64> for Gamma {
     }
 
     fn inverse_cdf(&self, p: f64) -> f64 {
-        const MAX_ITERS: (u16, u16) = (8, 4);
         if !(0.0..=1.0).contains(&p) {
             panic!("default inverse_cdf implementation should be provided probability on [0,1]")
         }
@@ -167,7 +166,7 @@ impl ContinuousCDF<f64, f64> for Gamma {
         }
         let mut x_0 = (high + low) / 2.0;
 
-        for _ in 0..MAX_ITERS.0 {
+        for _ in 0..8 {
             if self.cdf(x_0) >= p {
                 high = x_0;
             } else {
@@ -178,8 +177,8 @@ impl ContinuousCDF<f64, f64> for Gamma {
             }
         }
 
-        // NR method, guarantee at least one step
-        for _ in 0..MAX_ITERS.1 {
+        // Newton Raphson, for at least one step
+        for _ in 0..4 {
             let x_next = x_0 - (self.cdf(x_0) - p) / self.pdf(x_0);
             if prec::convergence(&mut x_0, x_next) {
                 break;

--- a/src/distribution/gamma.rs
+++ b/src/distribution/gamma.rs
@@ -133,17 +133,13 @@ impl ContinuousCDF<f64, f64> for Gamma {
     fn sf(&self, x: f64) -> f64 {
         if x <= 0.0 {
             1.0
-        }
-        else if ulps_eq!(x, self.shape) && self.rate.is_infinite() {
+        } else if ulps_eq!(x, self.shape) && self.rate.is_infinite() {
             0.0
-        }
-        else if self.rate.is_infinite() {
+        } else if self.rate.is_infinite() {
             1.0
-        }
-        else if x.is_infinite() {
+        } else if x.is_infinite() {
             0.0
-        }
-        else {
+        } else {
             gamma::gamma_ur(self.shape, x * self.rate)
         }
     }
@@ -502,7 +498,11 @@ mod tests {
         for &(arg, res) in test.iter() {
             test_case_special(arg, res, 10e-6, f);
         }
-        let test = [((10.0, 10.0), 0.9), ((10.0, 1.0), 9.0), ((10.0, f64::INFINITY), 0.0)];
+        let test = [
+            ((10.0, 10.0), 0.9),
+            ((10.0, 1.0), 9.0),
+            ((10.0, f64::INFINITY), 0.0),
+        ];
         for &(arg, res) in test.iter() {
             test_case(arg, res, f);
         }
@@ -624,6 +624,13 @@ mod tests {
                 let p = 10.0f64.powi(n);
                 test_case(param, p, f(p));
             }
+        }
+
+        // test case from issue #200
+        {
+            let x = 20.5567;
+            let f = |x: f64| move |g: Gamma| g.inverse_cdf(g.cdf(x));
+            test_case((3.0, 0.5), x, f(x))
         }
     }
 

--- a/src/prec.rs
+++ b/src/prec.rs
@@ -25,3 +25,12 @@ pub fn almost_eq(a: f64, b: f64, acc: f64) -> bool {
 
     (a - b).abs() < acc
 }
+
+/// Compares if two floats are close via `approx::relative_eq!`
+/// and `crate::consts::ACC` relative precision.
+/// Updates first argument to value of second argument
+pub fn convergence(x: &mut f64, x_new: f64) -> bool {
+    let res = approx::relative_eq!(*x, x_new, max_relative = crate::consts::ACC);
+    *x = x_new;
+    res
+}


### PR DESCRIPTION
Don't think there's a closed form expression for inverting the CDF, so this improves on the bisection approach with a few iterations of Newton-Raphson since we have `pdf` 

also adds tests