### PR TITLE
Add a way to easily get the standard normal distribution.

### DIFF
--- a/src/distribution/normal.rs
+++ b/src/distribution/normal.rs
@@ -51,6 +51,26 @@ impl Normal {
             Ok(Normal { mean, std_dev })
         }
     }
+
+    ///  Constructs a new standard normal distribution with a mean of 0
+    /// and a standard deviation of 1.
+    ///
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use statrs::distribution::Normal;
+    ///
+    /// let mut result = Normal::standard();
+    /// ```
+    pub fn new() -> Normal {
+        let mean: f64 = 0.0;
+        let std_dev: f64 = 1.0;
+        Normal {
+            mean,
+            std_dev
+        }
+    }
 }
 
 impl ::rand::distributions::Distribution<f64> for Normal {

--- a/src/distribution/normal.rs
+++ b/src/distribution/normal.rs
@@ -63,7 +63,7 @@ impl Normal {
     ///
     /// let mut result = Normal::standard();
     /// ```
-    pub fn new() -> Normal {
+    pub fn standard() -> Normal {
         let mean: f64 = 0.0;
         let std_dev: f64 = 1.0;
         Normal {

--- a/src/distribution/normal.rs
+++ b/src/distribution/normal.rs
@@ -52,7 +52,7 @@ impl Normal {
         }
     }
 
-    ///  Constructs a new standard normal distribution with a mean of 0
+    /// Constructs a new standard normal distribution with a mean of 0
     /// and a standard deviation of 1.
     ///
     ///
@@ -63,12 +63,10 @@ impl Normal {
     ///
     /// let mut result = Normal::standard();
     /// ```
-    pub fn standard() -> Normal {
-        let mean: f64 = 0.0;
-        let std_dev: f64 = 1.0;
+    fn standard() -> Normal {
         Normal {
-            mean,
-            std_dev
+            mean: 0.0,
+            std_dev: 1.0,
         }
     }
 }
@@ -306,6 +304,15 @@ pub fn ln_pdf_unchecked(x: f64, mean: f64, std_dev: f64) -> f64 {
 /// draws a sample from a normal distribution using the Box-Muller algorithm
 pub fn sample_unchecked<R: Rng + ?Sized>(rng: &mut R, mean: f64, std_dev: f64) -> f64 {
     mean + std_dev * ziggurat::sample_std_normal(rng)
+}
+
+
+impl std::default::Default for Normal {
+    /// Returns the standard normal distribution with a mean of 0
+    /// and a standard deviation of 1.
+    fn default() -> Self {
+        Self::standard()
+    }
 }
 
 #[rustfmt::skip]

--- a/src/distribution/normal.rs
+++ b/src/distribution/normal.rs
@@ -540,8 +540,8 @@ mod tests {
     fn test_default() {
         let n = Normal::default();
 
-        n_mean = n.mean().unwrap();
-        n_std  = n.std_dev().unwrap();
+        let n_mean = n.mean().unwrap();
+        let n_std  = n.std_dev().unwrap();
 
         // Check that the mean of the distribution is close to 0
         assert_almost_eq!(n_mean, 0.0, 1e-15);

--- a/src/distribution/normal.rs
+++ b/src/distribution/normal.rs
@@ -63,7 +63,7 @@ impl Normal {
     ///
     /// let mut result = Normal::standard();
     /// ```
-    fn standard() -> Normal {
+    pub fn standard() -> Normal {
         Normal {
             mean: 0.0,
             std_dev: 1.0,
@@ -534,5 +534,18 @@ mod tests {
         test_almost(5.0, 2.0, 6.0, 1e-14, inverse_cdf(0.69146246127401310363770461060833773988360217555457859));
         test_almost(5.0, 2.0, 10.0, 1e-14, inverse_cdf(0.9937903346742238648330218954258077788721022530769078));
         test_case(5.0, 2.0, f64::INFINITY, inverse_cdf(1.0));
+    }
+
+    #[test]
+    fn test_default() {
+        let n = Normal::default();
+
+        n_mean = n.mean().unwrap();
+        n_std  = n.std_dev().unwrap();
+
+        // Check that the mean of the distribution is close to 0
+        assert_almost_eq!(n_mean, 0.0, 1e-15);
+        // Check that the standard deviation of the distribution is close to 1
+        assert_almost_eq!(n_std, 1.0, 1e-15);
     }
 }


### PR DESCRIPTION
I've been using statrs and I love the project. I find myself creating the standard normal distribution frequently. So I thought it might be convenient to add a way to get the standard normal in one function call rather than unwrapping. Hope this is useful for others too.