### PR TITLE
Remove `feature = "nightly"` gate where unneeded

### DIFF
--- a/src/distribution/bernoulli.rs
+++ b/src/distribution/bernoulli.rs
@@ -257,7 +257,7 @@ impl Discrete<u64, f64> for Bernoulli {
 }
 
 #[rustfmt::skip]
-#[cfg(all(test, feature = "nightly"))]
+#[cfg(test)]
 mod testing {
     use std::fmt::Debug;
     use crate::distribution::DiscreteCDF;

--- a/src/distribution/dirac.rs
+++ b/src/distribution/dirac.rs
@@ -185,7 +185,7 @@ impl Mode<Option<f64>> for Dirac {
 }
 
 #[rustfmt::skip]
-#[cfg(all(test, feature = "nightly"))]
+#[cfg(test)]
 mod tests {
     use crate::statistics::*;
     use crate::distribution::{ContinuousCDF, Continuous, Dirac};

--- a/src/distribution/dirichlet.rs
+++ b/src/distribution/dirichlet.rs
@@ -301,7 +301,7 @@ fn is_valid_alpha(a: &[f64]) -> bool {
 }
 
 #[rustfmt::skip]
-#[cfg(all(test, feature = "nightly"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use nalgebra::{DVector};

--- a/src/distribution/discrete_uniform.rs
+++ b/src/distribution/discrete_uniform.rs
@@ -248,7 +248,7 @@ impl Discrete<i64, f64> for DiscreteUniform {
 }
 
 #[rustfmt::skip]
-#[cfg(all(test, feature = "nightly"))]
+#[cfg(test)]
 mod tests {
     use std::fmt::Debug;
     use crate::statistics::*;

--- a/src/distribution/empirical.rs
+++ b/src/distribution/empirical.rs
@@ -206,7 +206,7 @@ impl ContinuousCDF<f64, f64> for Empirical {
     }
 }
 
-#[cfg(all(test, feature = "nightly"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     #[test]

--- a/src/distribution/laplace.rs
+++ b/src/distribution/laplace.rs
@@ -291,7 +291,7 @@ impl Continuous<f64, f64> for Laplace {
     }
 }
 
-#[cfg(all(test, feature = "nightly"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use rand::thread_rng;

--- a/src/distribution/multivariate_normal.rs
+++ b/src/distribution/multivariate_normal.rs
@@ -242,7 +242,7 @@ impl Continuous<Vec<f64>, f64> for MultivariateNormal {
 }
 
 #[rustfmt::skip]
-#[cfg(all(test, feature = "nightly"))]
+#[cfg(test)]
 mod tests  {
     use crate::distribution::{Continuous, MultivariateNormal};
     use crate::statistics::*;


### PR DESCRIPTION
The `nightly` feature hides some testing helpers and macros, and all tests using any of them need to be hidden behind the `nightly` feature too.

This isn't great (see #228) and I want to increase the amount of tests that can be run without unstable and/or nightly compiler features. The tests modified in this PR are low-hanging fruit, they don't require any nightly feature at all.
