### PR TITLE
Update testing_boiler macro to not need a nightly compiler

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,20 +41,12 @@ jobs:
     strategy:
       matrix:
           os: [ubuntu-latest, macos-latest, windows-latest]
-          toolchain: [stable, nightly]
 
     steps:
       - uses: actions/checkout@v4
-      - name: Install Rust ${{ matrix.toolchain }}
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ matrix.toolchain }}
-
-      - name: Test nightly feature
-        if: matrix.toolchain == 'nightly'
-        run: cargo test --all-targets --features=nightly
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Test default features
-        if: matrix.toolchain != 'nightly'
         run: cargo test --all-targets
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,6 @@ include = ["CHANGELOG.md", "LICENSE.md", "src/"]
 name = "statrs"
 path = "src/lib.rs"
 
-[features]
-nightly = []
-
 [dependencies]
 rand = "0.8"
 nalgebra = { version = "0.32", features = ["rand"] }

--- a/src/distribution/beta.rs
+++ b/src/distribution/beta.rs
@@ -410,13 +410,13 @@ mod tests {
     use crate::statistics::*;
     use crate::testing_boiler;
 
-    testing_boiler!((f64, f64), Beta);
+    testing_boiler!(a: f64, b: f64; Beta);
 
     #[test]
     fn test_create() {
         let valid = [(1.0, 1.0), (9.0, 1.0), (5.0, 100.0), (1.0, f64::INFINITY), (f64::INFINITY, 1.0)];
-        for &arg in valid.iter() {
-            try_create(arg);
+        for (a, b) in valid {
+            try_create(a, b);
         }
     }
 
@@ -436,8 +436,8 @@ mod tests {
             (-1.0, -1.0),
             (f64::INFINITY, f64::INFINITY),
         ];
-        for &arg in invalid.iter() {
-            bad_create_case(arg);
+        for (a, b) in invalid {
+            bad_create_case(a, b);
         }
     }
 
@@ -451,8 +451,8 @@ mod tests {
             ((1.0, f64::INFINITY), 0.0),
             ((f64::INFINITY, 1.0), 1.0),
         ];
-        for &(arg, res) in test.iter() {
-            test_case(arg, res, f);
+        for ((a, b), res) in test {
+            test_case(a, b, res, f);
         }
     }
 
@@ -466,8 +466,8 @@ mod tests {
             ((1.0, f64::INFINITY), 0.0),
             ((f64::INFINITY, 1.0), 0.0),
         ];
-        for &(arg, res) in test.iter() {
-            test_case(arg, res, f);
+        for ((a, b), res) in test {
+            test_case(a, b, res, f);
         }
     }
 
@@ -478,53 +478,53 @@ mod tests {
             ((9.0, 1.0), -1.3083356884473304939016015),
             ((5.0, 100.0), -2.52016231876027436794592),
         ];
-        for &(arg, res) in test.iter() {
-            test_case(arg, res, f);
+        for ((a, b), res) in test {
+            test_case(a, b, res, f);
         }
-        test_case_special((1.0, 1.0), 0.0, 1e-14, f);
+        test_case_special(1.0, 1.0, 0.0, 1e-14, f);
         let entropy = |x: Beta| x.entropy();
-        test_none((1.0, f64::INFINITY), entropy);
-        test_none((f64::INFINITY, 1.0), entropy);
+        test_none(1.0, f64::INFINITY, entropy);
+        test_none(f64::INFINITY, 1.0, entropy);
     }
 
     #[test]
     fn test_skewness() {
         let skewness = |x: Beta| x.skewness().unwrap();
-        test_case((1.0, 1.0), 0.0, skewness);
-        test_case((9.0, 1.0), -1.4740554623801777107177478829, skewness);
-        test_case((5.0, 100.0), 0.817594109275534303545831591, skewness);
-        test_case((1.0, f64::INFINITY), 2.0, skewness);
-        test_case((f64::INFINITY, 1.0), -2.0, skewness);
+        test_case(1.0, 1.0, 0.0, skewness);
+        test_case(9.0, 1.0, -1.4740554623801777107177478829, skewness);
+        test_case(5.0, 100.0, 0.817594109275534303545831591, skewness);
+        test_case(1.0, f64::INFINITY, 2.0, skewness);
+        test_case(f64::INFINITY, 1.0, -2.0, skewness);
     }
 
     #[test]
     fn test_mode() {
         let mode = |x: Beta| x.mode().unwrap();
-        test_case((5.0, 100.0), 0.038834951456310676243255386, mode);
-        test_case((92.0, f64::INFINITY), 0.0, mode);
-        test_case((f64::INFINITY, 2.0), 1.0, mode);
+        test_case(5.0, 100.0, 0.038834951456310676243255386, mode);
+        test_case(92.0, f64::INFINITY, 0.0, mode);
+        test_case(f64::INFINITY, 2.0, 1.0, mode);
     }
 
     #[test]
     #[should_panic]
     fn test_mode_shape_a_lte_1() {
         let mode = |x: Beta| x.mode().unwrap();
-        get_value((1.0, 5.0), mode);
+        get_value(1.0, 5.0, mode);
     }
 
     #[test]
     #[should_panic]
     fn test_mode_shape_b_lte_1() {
         let mode = |x: Beta| x.mode().unwrap();
-        get_value((5.0, 1.0), mode);
+        get_value(5.0, 1.0, mode);
     }
 
     #[test]
     fn test_min_max() {
         let min = |x: Beta| x.min();
         let max = |x: Beta| x.max();
-        test_case((1.0, 1.0), 0.0, min);
-        test_case((1.0, 1.0), 1.0, max);
+        test_case(1.0, 1.0, 0.0, min);
+        test_case(1.0, 1.0, 1.0, max);
     }
 
     #[test]
@@ -548,21 +548,21 @@ mod tests {
             ((f64::INFINITY, 1.0), 0.5, 0.0),
             ((f64::INFINITY, 1.0), 1.0, f64::INFINITY),
         ];
-        for &(arg, x, expect) in test.iter() {
-            test_case(arg, expect, f(x));
+        for ((a, b), x, expect) in test {
+            test_case(a, b, expect, f(x));
         }
     }
 
     #[test]
     fn test_pdf_input_lt_0() {
         let pdf = |arg: f64| move |x: Beta| x.pdf(arg);
-        test_case((1.0, 1.0), 0.0, pdf(-1.0));
+        test_case(1.0, 1.0, 0.0, pdf(-1.0));
     }
 
     #[test]
     fn test_pdf_input_gt_0() {
         let pdf = |arg: f64| move |x: Beta| x.pdf(arg);
-        test_case((1.0, 1.0), 0.0, pdf(2.0));
+        test_case(1.0, 1.0, 0.0, pdf(2.0));
     }
 
     #[test]
@@ -585,21 +585,21 @@ mod tests {
             ((f64::INFINITY, 1.0), 0.5, f64::NEG_INFINITY),
             ((f64::INFINITY, 1.0), 1.0, f64::INFINITY),
         ];
-        for &(arg, x, expect) in test.iter() {
-            test_case(arg, expect, f(x));
+        for ((a, b), x, expect) in test {
+            test_case(a, b, expect, f(x));
         }
     }
 
     #[test]
     fn test_ln_pdf_input_lt_0() {
         let ln_pdf = |arg: f64| move |x: Beta| x.ln_pdf(arg);
-        test_case((1.0, 1.0), f64::NEG_INFINITY, ln_pdf(-1.0));
+        test_case(1.0, 1.0, f64::NEG_INFINITY, ln_pdf(-1.0));
     }
 
     #[test]
     fn test_ln_pdf_input_gt_1() {
         let ln_pdf = |arg: f64| move |x: Beta| x.ln_pdf(arg);
-        test_case((1.0, 1.0), f64::NEG_INFINITY, ln_pdf(2.0));
+        test_case(1.0, 1.0, f64::NEG_INFINITY, ln_pdf(2.0));
     }
 
     #[test]
@@ -622,8 +622,8 @@ mod tests {
             ((f64::INFINITY, 1.0), 0.5, 0.0),
             ((f64::INFINITY, 1.0), 1.0, 1.0),
         ];
-        for &(arg, x, expect) in test.iter() {
-            test_case(arg, expect, cdf(x));
+        for ((a, b), x, expect) in test {
+            test_case(a, b, expect, cdf(x));
         }
     }
 
@@ -647,38 +647,38 @@ mod tests {
             ((f64::INFINITY, 1.0), 0.5, 1.0),
             ((f64::INFINITY, 1.0), 1.0, 0.0),
         ];
-        for &(arg, x, expect) in test.iter() {
-            test_case(arg, expect, sf(x));
+        for ((a, b), x, expect) in test {
+            test_case(a, b, expect, sf(x));
         }
     }
 
     #[test]
     fn test_cdf_input_lt_0() {
         let cdf = |arg: f64| move |x: Beta| x.cdf(arg);
-        test_case((1.0, 1.0), 0.0, cdf(-1.0));
+        test_case(1.0, 1.0, 0.0, cdf(-1.0));
     }
 
     #[test]
     fn test_cdf_input_gt_1() {
         let cdf = |arg: f64| move |x: Beta| x.cdf(arg);
-        test_case((1.0, 1.0), 1.0, cdf(2.0));
+        test_case(1.0, 1.0, 1.0, cdf(2.0));
     }
 
     #[test]
     fn test_sf_input_lt_0() {
         let sf = |arg: f64| move |x: Beta| x.sf(arg);
-        test_case((1.0, 1.0), 1.0, sf(-1.0));
+        test_case(1.0, 1.0, 1.0, sf(-1.0));
     }
 
     #[test]
     fn test_sf_input_gt_1() {
         let sf = |arg: f64| move |x: Beta| x.sf(arg);
-        test_case((1.0, 1.0), 0.0, sf(2.0));
+        test_case(1.0, 1.0, 0.0, sf(2.0));
     }
 
     #[test]
     fn test_continuous() {
-        test::check_continuous_distribution(&try_create((1.2, 3.4)), 0.0, 1.0);
-        test::check_continuous_distribution(&try_create((4.5, 6.7)), 0.0, 1.0);
+        test::check_continuous_distribution(&try_create(1.2, 3.4), 0.0, 1.0);
+        test::check_continuous_distribution(&try_create(4.5, 6.7), 0.0, 1.0);
     }
 }

--- a/src/distribution/beta.rs
+++ b/src/distribution/beta.rs
@@ -405,7 +405,6 @@ impl Continuous<f64, f64> for Beta {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::consts::ACC;
     use super::super::internal::*;
     use crate::statistics::*;
     use crate::testing_boiler;

--- a/src/distribution/beta.rs
+++ b/src/distribution/beta.rs
@@ -402,7 +402,7 @@ impl Continuous<f64, f64> for Beta {
 }
 
 #[rustfmt::skip]
-#[cfg(all(test, feature = "nightly"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::consts::ACC;

--- a/src/distribution/binomial.rs
+++ b/src/distribution/binomial.rs
@@ -327,7 +327,6 @@ mod tests {
     use crate::statistics::*;
     use crate::distribution::{DiscreteCDF, Discrete, Binomial};
     use crate::distribution::internal::*;
-    use crate::consts::ACC;
 
     fn try_create(p: f64, n: u64) -> Binomial {
         let n = Binomial::new(p, n);

--- a/src/distribution/binomial.rs
+++ b/src/distribution/binomial.rs
@@ -321,7 +321,7 @@ impl Discrete<u64, f64> for Binomial {
 }
 
 #[rustfmt::skip]
-#[cfg(all(test, feature = "nightly"))]
+#[cfg(test)]
 mod tests {
     use std::fmt::Debug;
     use crate::statistics::*;

--- a/src/distribution/categorical.rs
+++ b/src/distribution/categorical.rs
@@ -344,7 +344,7 @@ fn test_binary_index() {
 }
 
 #[rustfmt::skip]
-#[cfg(all(test, feature = "nightly"))]
+#[cfg(test)]
 mod tests {
     use std::fmt::Debug;
     use crate::statistics::*;

--- a/src/distribution/categorical.rs
+++ b/src/distribution/categorical.rs
@@ -350,7 +350,6 @@ mod tests {
     use crate::statistics::*;
     use crate::distribution::{Categorical, Discrete, DiscreteCDF};
     use crate::distribution::internal::*;
-    use crate::consts::ACC;
 
     fn try_create(prob_mass: &[f64]) -> Categorical {
         let n = Categorical::new(prob_mass);

--- a/src/distribution/cauchy.rs
+++ b/src/distribution/cauchy.rs
@@ -226,7 +226,7 @@ impl Continuous<f64, f64> for Cauchy {
 }
 
 #[rustfmt::skip]
-#[cfg(all(test, feature = "nightly"))]
+#[cfg(test)]
 mod tests {
     use crate::statistics::*;
     use crate::distribution::{ContinuousCDF, Continuous, Cauchy};

--- a/src/distribution/cauchy.rs
+++ b/src/distribution/cauchy.rs
@@ -231,7 +231,6 @@ mod tests {
     use crate::statistics::*;
     use crate::distribution::{ContinuousCDF, Continuous, Cauchy};
     use crate::distribution::internal::*;
-    use crate::consts::ACC;
 
     fn try_create(location: f64, scale: f64) -> Cauchy {
         let n = Cauchy::new(location, scale);

--- a/src/distribution/chi.rs
+++ b/src/distribution/chi.rs
@@ -317,7 +317,7 @@ impl Continuous<f64, f64> for Chi {
 }
 
 #[rustfmt::skip]
-#[cfg(all(test, feature = "nightly"))]
+#[cfg(test)]
 mod tests {
     use std::f64;
     use crate::distribution::internal::*;

--- a/src/distribution/chi.rs
+++ b/src/distribution/chi.rs
@@ -323,7 +323,6 @@ mod tests {
     use crate::distribution::internal::*;
     use crate::distribution::{Chi, Continuous, ContinuousCDF};
     use crate::statistics::*;
-    use crate::consts::ACC;
 
     fn try_create(freedom: f64) -> Chi {
         let n = Chi::new(freedom);

--- a/src/distribution/chi_squared.rs
+++ b/src/distribution/chi_squared.rs
@@ -288,7 +288,6 @@ mod tests {
     use crate::statistics::Median;
     use crate::distribution::ChiSquared;
     use crate::distribution::internal::*;
-    use crate::consts::ACC;
 
     fn try_create(freedom: f64) -> ChiSquared {
         let n = ChiSquared::new(freedom);

--- a/src/distribution/chi_squared.rs
+++ b/src/distribution/chi_squared.rs
@@ -283,7 +283,7 @@ impl Continuous<f64, f64> for ChiSquared {
 }
 
 #[rustfmt::skip]
-#[cfg(all(test, feature = "nightly"))]
+#[cfg(test)]
 mod tests {
     use crate::statistics::Median;
     use crate::distribution::ChiSquared;

--- a/src/distribution/dirac.rs
+++ b/src/distribution/dirac.rs
@@ -189,7 +189,6 @@ impl Mode<Option<f64>> for Dirac {
 mod tests {
     use crate::statistics::*;
     use crate::distribution::{ContinuousCDF, Continuous, Dirac};
-    use crate::consts::ACC;
 
     fn try_create(v: f64) -> Dirac {
         let d = Dirac::new(v);

--- a/src/distribution/dirichlet.rs
+++ b/src/distribution/dirichlet.rs
@@ -308,7 +308,6 @@ mod tests {
     use crate::function::gamma;
     use crate::statistics::*;
     use crate::distribution::{Continuous, Dirichlet};
-    use crate::consts::ACC;
 
     #[test]
     fn test_is_valid_alpha() {

--- a/src/distribution/discrete_uniform.rs
+++ b/src/distribution/discrete_uniform.rs
@@ -253,7 +253,6 @@ mod tests {
     use std::fmt::Debug;
     use crate::statistics::*;
     use crate::distribution::{DiscreteCDF, Discrete, DiscreteUniform};
-    use crate::consts::ACC;
 
     fn try_create(min: i64, max: i64) -> DiscreteUniform {
         let n = DiscreteUniform::new(min, max);

--- a/src/distribution/erlang.rs
+++ b/src/distribution/erlang.rs
@@ -270,7 +270,7 @@ impl Continuous<f64, f64> for Erlang {
 }
 
 #[rustfmt::skip]
-#[cfg(all(test, feature = "nightly"))]
+#[cfg(test)]
 mod tests {
     use crate::distribution::Erlang;
     use crate::distribution::internal::*;

--- a/src/distribution/erlang.rs
+++ b/src/distribution/erlang.rs
@@ -274,7 +274,6 @@ impl Continuous<f64, f64> for Erlang {
 mod tests {
     use crate::distribution::Erlang;
     use crate::distribution::internal::*;
-    use crate::consts::ACC;
 
     fn try_create(shape: u64, rate: f64) -> Erlang {
         let n = Erlang::new(shape, rate);

--- a/src/distribution/exponential.rs
+++ b/src/distribution/exponential.rs
@@ -277,7 +277,6 @@ mod tests {
     use crate::statistics::*;
     use crate::distribution::{ContinuousCDF, Continuous, Exp};
     use crate::distribution::internal::*;
-    use crate::consts::ACC;
 
     fn try_create(rate: f64) -> Exp {
         let n = Exp::new(rate);

--- a/src/distribution/exponential.rs
+++ b/src/distribution/exponential.rs
@@ -271,7 +271,7 @@ impl Continuous<f64, f64> for Exp {
 }
 
 #[rustfmt::skip]
-#[cfg(all(test, feature = "nightly"))]
+#[cfg(test)]
 mod tests {
     use std::f64;
     use crate::statistics::*;

--- a/src/distribution/fisher_snedecor.rs
+++ b/src/distribution/fisher_snedecor.rs
@@ -360,7 +360,6 @@ mod tests {
     use crate::statistics::*;
     use crate::distribution::{ContinuousCDF, Continuous, FisherSnedecor};
     use crate::distribution::internal::*;
-    use crate::consts::ACC;
 
     fn try_create(freedom_1: f64, freedom_2: f64) -> FisherSnedecor {
         let n = FisherSnedecor::new(freedom_1, freedom_2);

--- a/src/distribution/fisher_snedecor.rs
+++ b/src/distribution/fisher_snedecor.rs
@@ -355,7 +355,7 @@ impl Continuous<f64, f64> for FisherSnedecor {
 }
 
 #[rustfmt::skip]
-#[cfg(all(test, feature = "nightly"))]
+#[cfg(test)]
 mod tests {
     use crate::statistics::*;
     use crate::distribution::{ContinuousCDF, Continuous, FisherSnedecor};

--- a/src/distribution/gamma.rs
+++ b/src/distribution/gamma.rs
@@ -401,7 +401,6 @@ pub fn sample_unchecked<R: Rng + ?Sized>(rng: &mut R, shape: f64, rate: f64) -> 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::consts::ACC;
     use crate::distribution::internal::*;
     use crate::testing_boiler;
 

--- a/src/distribution/gamma.rs
+++ b/src/distribution/gamma.rs
@@ -405,7 +405,7 @@ mod tests {
     use crate::distribution::internal::*;
     use crate::testing_boiler;
 
-    testing_boiler!((f64, f64), Gamma);
+    testing_boiler!(shape: f64, rate: f64; Gamma);
 
     #[test]
     fn test_create() {
@@ -417,8 +417,8 @@ mod tests {
             (10.0, f64::INFINITY),
         ];
 
-        for &arg in valid.iter() {
-            try_create(arg);
+        for (s, r) in valid {
+            try_create(s, r);
         }
     }
 
@@ -432,8 +432,8 @@ mod tests {
             (-1.0, -1.0),
             (-1.0, f64::NAN),
         ];
-        for &arg in invalid.iter() {
-            bad_create_case(arg);
+        for (s, r) in invalid {
+            bad_create_case(s, r);
         }
     }
 
@@ -447,8 +447,8 @@ mod tests {
             ((10.0, 1.0), 10.0),
             ((10.0, f64::INFINITY), 0.0),
         ];
-        for &(arg, res) in test.iter() {
-            test_case(arg, res, f);
+        for ((s, r), res) in test {
+            test_case(s, r, res, f);
         }
     }
 
@@ -462,8 +462,8 @@ mod tests {
             ((10.0, 1.0), 10.0),
             ((10.0, f64::INFINITY), 0.0),
         ];
-        for &(arg, res) in test.iter() {
-            test_case(arg, res, f);
+        for ((s, r), res) in test {
+            test_case(s, r, res, f);
         }
     }
 
@@ -477,8 +477,8 @@ mod tests {
             ((10.0, 1.0), 2.53605417848097964238061239),
             ((10.0, f64::INFINITY), f64::NEG_INFINITY),
         ];
-        for &(arg, res) in test.iter() {
-            test_case(arg, res, f);
+        for ((s, r), res) in test {
+            test_case(s, r, res, f);
         }
     }
 
@@ -492,8 +492,8 @@ mod tests {
             ((10.0, 1.0), 0.63245553203367586639977870),
             ((10.0, f64::INFINITY), 0.6324555320336758),
         ];
-        for &(arg, res) in test.iter() {
-            test_case(arg, res, f);
+        for ((s, r), res) in test {
+            test_case(s, r, res, f);
         }
     }
 
@@ -501,16 +501,16 @@ mod tests {
     fn test_mode() {
         let f = |x: Gamma| x.mode().unwrap();
         let test = [((1.0, 0.1), 0.0), ((1.0, 1.0), 0.0)];
-        for &(arg, res) in test.iter() {
-            test_case_special(arg, res, 10e-6, f);
+        for &((s, r), res) in test.iter() {
+            test_case_special(s, r, res, 10e-6, f);
         }
         let test = [
             ((10.0, 10.0), 0.9),
             ((10.0, 1.0), 9.0),
             ((10.0, f64::INFINITY), 0.0),
         ];
-        for &(arg, res) in test.iter() {
-            test_case(arg, res, f);
+        for ((s, r), res) in test {
+            test_case(s, r, res, f);
         }
     }
 
@@ -524,8 +524,8 @@ mod tests {
             ((10.0, 1.0), 0.0),
             ((10.0, f64::INFINITY), 0.0),
         ];
-        for &(arg, res) in test.iter() {
-            test_case(arg, res, f);
+        for ((s, r), res) in test {
+            test_case(s, r, res, f);
         }
         let f = |x: Gamma| x.max();
         let test = [
@@ -535,8 +535,8 @@ mod tests {
             ((10.0, 1.0), f64::INFINITY),
             ((10.0, f64::INFINITY), f64::INFINITY),
         ];
-        for &(arg, res) in test.iter() {
-            test_case(arg, res, f);
+        for ((s, r), res) in test {
+            test_case(s, r, res, f);
         }
     }
 
@@ -553,8 +553,8 @@ mod tests {
             ((10.0, 1.0), 1.0, 0.000001013777119630297402),
             ((10.0, 1.0), 10.0, 0.125110035721133298984764),
         ];
-        for &(arg, x, res) in test.iter() {
-            test_case(arg, res, f(x));
+        for ((s, r), x, res) in test {
+            test_case(s, r, res, f(x));
         }
         // TODO: test special
         // test_is_nan((10.0, f64::INFINITY), pdf(1.0)); // is this really the behavior we want?
@@ -564,8 +564,8 @@ mod tests {
 
     #[test]
     fn test_pdf_at_zero() {
-        test_case((1.0, 0.1), 0.1, |x| x.pdf(0.0));
-        test_case((1.0, 0.1), 0.1f64.ln(), |x| x.ln_pdf(0.0));
+        test_case(1.0, 0.1, 0.1, |x| x.pdf(0.0));
+        test_case(1.0, 0.1, 0.1f64.ln(), |x| x.ln_pdf(0.0));
     }
 
     #[test]
@@ -582,8 +582,8 @@ mod tests {
             ((10.0, 1.0), 10.0, -2.07856164313505845504579),
             ((10.0, f64::INFINITY), f64::INFINITY, f64::NEG_INFINITY),
         ];
-        for &(arg, x, res) in test.iter() {
-            test_case(arg, res, f(x));
+        for ((s, r), x, res) in test {
+            test_case(s, r, res, f(x));
         }
         // TODO: test special
         // test_is_nan((10.0, f64::INFINITY), f(1.0)); // is this really the behavior we want?
@@ -604,14 +604,14 @@ mod tests {
             ((10.0, f64::INFINITY), 1.0, 0.0),
             ((10.0, f64::INFINITY), 10.0, 1.0),
         ];
-        for &(arg, x, res) in test.iter() {
-            test_case(arg, res, f(x));
+        for ((s, r), x, res) in test {
+            test_case(s, r, res, f(x));
         }
     }
 
     #[test]
     fn test_cdf_at_zero() {
-        test_case((1.0, 0.1), 0.0, |x| x.cdf(0.0));
+        test_case(1.0, 0.1, 0.0, |x| x.cdf(0.0));
     }
 
     #[test]
@@ -625,10 +625,10 @@ mod tests {
             (100.0, 200.0),
         ];
 
-        for param in params {
+        for (s, r) in params {
             for n in -5..0 {
                 let p = 10.0f64.powi(n);
-                test_case(param, p, f(p));
+                test_case(s, r, p, f(p));
             }
         }
 
@@ -636,7 +636,7 @@ mod tests {
         {
             let x = 20.5567;
             let f = |x: f64| move |g: Gamma| g.inverse_cdf(g.cdf(x));
-            test_case((3.0, 0.5), x, f(x))
+            test_case(3.0, 0.5, x, f(x))
         }
     }
 
@@ -655,19 +655,19 @@ mod tests {
             ((10.0, f64::INFINITY), 1.0, 1.0),
             ((10.0, f64::INFINITY), 10.0, 0.0),
         ];
-        for &(arg, x, res) in test.iter() {
-            test_case(arg, res, f(x));
+        for ((s, r), x, res) in test {
+            test_case(s, r, res, f(x));
         }
     }
 
     #[test]
     fn test_sf_at_zero() {
-        test_case((1.0, 0.1), 1.0, |x| x.sf(0.0));
+        test_case(1.0, 0.1, 1.0, |x| x.sf(0.0));
     }
 
     #[test]
     fn test_continuous() {
-        test::check_continuous_distribution(&try_create((1.0, 0.5)), 0.0, 20.0);
-        test::check_continuous_distribution(&try_create((9.0, 2.0)), 0.0, 20.0);
+        test::check_continuous_distribution(&try_create(1.0, 0.5), 0.0, 20.0);
+        test::check_continuous_distribution(&try_create(9.0, 2.0), 0.0, 20.0);
     }
 }

--- a/src/distribution/gamma.rs
+++ b/src/distribution/gamma.rs
@@ -398,7 +398,7 @@ pub fn sample_unchecked<R: Rng + ?Sized>(rng: &mut R, shape: f64, rate: f64) -> 
     }
 }
 
-#[cfg(all(test, feature = "nightly"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::consts::ACC;

--- a/src/distribution/geometric.rs
+++ b/src/distribution/geometric.rs
@@ -265,7 +265,7 @@ impl Discrete<u64, f64> for Geometric {
 }
 
 #[rustfmt::skip]
-#[cfg(all(test, feature = "nightly"))]
+#[cfg(test)]
 mod tests {
     use std::fmt::Debug;
     use crate::statistics::*;

--- a/src/distribution/geometric.rs
+++ b/src/distribution/geometric.rs
@@ -271,7 +271,6 @@ mod tests {
     use crate::statistics::*;
     use crate::distribution::{DiscreteCDF, Discrete, Geometric};
     use crate::distribution::internal::*;
-    use crate::consts::ACC;
 
     fn try_create(p: f64) -> Geometric {
         let n = Geometric::new(p);

--- a/src/distribution/hypergeometric.rs
+++ b/src/distribution/hypergeometric.rs
@@ -366,7 +366,7 @@ impl Discrete<u64, f64> for Hypergeometric {
 }
 
 #[rustfmt::skip]
-#[cfg(all(test, feature = "nightly"))]
+#[cfg(test)]
 mod tests {
     use std::fmt::Debug;
     use crate::statistics::*;

--- a/src/distribution/hypergeometric.rs
+++ b/src/distribution/hypergeometric.rs
@@ -372,7 +372,6 @@ mod tests {
     use crate::statistics::*;
     use crate::distribution::{DiscreteCDF, Discrete, Hypergeometric};
     use crate::distribution::internal::*;
-    use crate::consts::ACC;
 
     fn try_create(population: u64, successes: u64, draws: u64) -> Hypergeometric {
         let n = Hypergeometric::new(population, successes, draws);

--- a/src/distribution/internal.rs
+++ b/src/distribution/internal.rs
@@ -55,7 +55,7 @@ pub fn integral_bisection_search<K: Num + Clone, T: Num + PartialOrd>(
 }
 
 #[macro_use]
-#[cfg(all(test, feature = "nightly"))]
+#[cfg(test)]
 pub mod test {
     use super::*;
     use crate::consts::ACC;

--- a/src/distribution/internal.rs
+++ b/src/distribution/internal.rs
@@ -63,52 +63,52 @@ pub mod test {
 
     #[macro_export]
     macro_rules! testing_boiler {
-        ($arg:ty, $dist:ty) => {
-            fn try_create(arg: $arg) -> $dist {
-                let n = <$dist>::new.call_once(arg);
+        ($($arg_name:ident: $arg_ty:ty),+; $dist:ty) => {
+            fn try_create($($arg_name: $arg_ty),+) -> $dist {
+                let n = <$dist>::new($($arg_name),+);
                 assert!(n.is_ok());
                 n.unwrap()
             }
 
-            fn bad_create_case(arg: $arg) {
-                let n = <$dist>::new.call(arg);
+            fn bad_create_case($($arg_name: $arg_ty),+) {
+                let n = <$dist>::new($($arg_name),+);
                 assert!(n.is_err());
             }
 
-            fn get_value<F, T>(arg: $arg, eval: F) -> T
+            fn get_value<F, T>($($arg_name: $arg_ty),+, eval: F) -> T
             where
                 F: Fn($dist) -> T,
             {
-                let n = try_create(arg);
+                let n = try_create($($arg_name),+);
                 eval(n)
             }
 
-            fn test_case<F, T>(arg: $arg, expected: T, eval: F)
+            fn test_case<F, T>($($arg_name: $arg_ty),+, expected: T, eval: F)
             where
                 F: Fn($dist) -> T,
                 T: ::core::fmt::Debug + ::approx::RelativeEq<Epsilon = f64>,
             {
-                let x = get_value(arg, eval);
+                let x = get_value($($arg_name),+, eval);
                 assert_relative_eq!(expected, x, max_relative = ACC);
             }
 
             #[allow(dead_code)] // This is not used by all distributions.
-            fn test_case_special<F, T>(arg: $arg, expected: T, acc: f64, eval: F)
+            fn test_case_special<F, T>($($arg_name: $arg_ty),+, expected: T, acc: f64, eval: F)
             where
                 F: Fn($dist) -> T,
                 T: ::core::fmt::Debug + ::approx::AbsDiffEq<Epsilon = f64>,
             {
-                let x = get_value(arg, eval);
+                let x = get_value($($arg_name),+, eval);
                 assert_abs_diff_eq!(expected, x, epsilon = acc);
             }
 
             #[allow(dead_code)] // This is not used by all distributions.
-            fn test_none<F, T>(arg: $arg, eval: F)
+            fn test_none<F, T>($($arg_name: $arg_ty),+, eval: F)
             where
                 F: Fn($dist) -> Option<T>,
                 T: ::core::cmp::PartialEq + ::core::fmt::Debug,
             {
-                let x = get_value(arg, eval);
+                let x = get_value($($arg_name),+, eval);
                 assert_eq!(None, x);
             }
         };

--- a/src/distribution/internal.rs
+++ b/src/distribution/internal.rs
@@ -240,7 +240,7 @@ pub mod test {
 
     #[test]
     fn test_integer_bisection() {
-        fn search(z: usize, data: &Vec<usize>) -> Option<usize> {
+        fn search(z: usize, data: &[usize]) -> Option<usize> {
             integral_bisection_search(|idx: &usize| data[*idx], z, 0, data.len() - 1)
         }
 

--- a/src/distribution/internal.rs
+++ b/src/distribution/internal.rs
@@ -58,7 +58,6 @@ pub fn integral_bisection_search<K: Num + Clone, T: Num + PartialOrd>(
 #[cfg(test)]
 pub mod test {
     use super::*;
-    use crate::consts::ACC;
     use crate::distribution::{Continuous, ContinuousCDF, Discrete, DiscreteCDF};
 
     #[macro_export]
@@ -89,7 +88,7 @@ pub mod test {
                 T: ::core::fmt::Debug + ::approx::RelativeEq<Epsilon = f64>,
             {
                 let x = get_value($($arg_name),+, eval);
-                assert_relative_eq!(expected, x, max_relative = ACC);
+                assert_relative_eq!(expected, x, max_relative = $crate::consts::ACC);
             }
 
             #[allow(dead_code)] // This is not used by all distributions.

--- a/src/distribution/inverse_gamma.rs
+++ b/src/distribution/inverse_gamma.rs
@@ -310,7 +310,6 @@ mod tests {
     use crate::statistics::*;
     use crate::distribution::{ContinuousCDF, Continuous, InverseGamma};
     use crate::distribution::internal::*;
-    use crate::consts::ACC;
 
     fn try_create(shape: f64, rate: f64) -> InverseGamma {
         let n = InverseGamma::new(shape, rate);

--- a/src/distribution/inverse_gamma.rs
+++ b/src/distribution/inverse_gamma.rs
@@ -305,7 +305,7 @@ impl Continuous<f64, f64> for InverseGamma {
 }
 
 #[rustfmt::skip]
-#[cfg(all(test, feature = "nightly"))]
+#[cfg(test)]
 mod tests {
     use crate::statistics::*;
     use crate::distribution::{ContinuousCDF, Continuous, InverseGamma};

--- a/src/distribution/log_normal.rs
+++ b/src/distribution/log_normal.rs
@@ -297,7 +297,7 @@ impl Continuous<f64, f64> for LogNormal {
 }
 
 #[rustfmt::skip]
-#[cfg(all(test, feature = "nightly"))]
+#[cfg(test)]
 mod tests {
     use crate::statistics::*;
     use crate::distribution::{ContinuousCDF, Continuous, LogNormal};

--- a/src/distribution/log_normal.rs
+++ b/src/distribution/log_normal.rs
@@ -302,7 +302,6 @@ mod tests {
     use crate::statistics::*;
     use crate::distribution::{ContinuousCDF, Continuous, LogNormal};
     use crate::distribution::internal::*;
-    use crate::consts::ACC;
 
     fn try_create(mean: f64, std_dev: f64) -> LogNormal {
         let n = LogNormal::new(mean, std_dev);

--- a/src/distribution/multinomial.rs
+++ b/src/distribution/multinomial.rs
@@ -244,7 +244,6 @@ impl<'a> Discrete<&'a [u64], f64> for Multinomial {
 // mod tests {
 //     use crate::statistics::*;
 //     use crate::distribution::{Discrete, Multinomial};
-//     use crate::consts::ACC;
 
 //     fn try_create(p: &[f64], n: u64) -> Multinomial {
 //         let dist = Multinomial::new(p, n);

--- a/src/distribution/multivariate_normal.rs
+++ b/src/distribution/multivariate_normal.rs
@@ -246,7 +246,6 @@ impl Continuous<Vec<f64>, f64> for MultivariateNormal {
 mod tests  {
     use crate::distribution::{Continuous, MultivariateNormal};
     use crate::statistics::*;
-    use crate::consts::ACC;
     use core::fmt::Debug;
     use nalgebra::base::allocator::Allocator;
     use nalgebra::{

--- a/src/distribution/negative_binomial.rs
+++ b/src/distribution/negative_binomial.rs
@@ -395,7 +395,7 @@ mod tests {
         let min = |x: NegativeBinomial| x.min();
         let max = |x: NegativeBinomial| x.max();
         test_case(1.0, 0.5, 0, min);
-        test_case(1.0, 0.3, std::u64::MAX, max);
+        test_case(1.0, 0.3, u64::MAX, max);
     }
 
     #[test]

--- a/src/distribution/negative_binomial.rs
+++ b/src/distribution/negative_binomial.rs
@@ -283,7 +283,7 @@ impl Discrete<u64, f64> for NegativeBinomial {
 }
 
 #[rustfmt::skip]
-#[cfg(all(test, feature = "nightly"))]
+#[cfg(test)]
 mod tests {
     use std::fmt::Debug;
     use crate::statistics::*;

--- a/src/distribution/negative_binomial.rs
+++ b/src/distribution/negative_binomial.rs
@@ -289,7 +289,6 @@ mod tests {
     use crate::statistics::*;
     use crate::distribution::{DiscreteCDF, Discrete, NegativeBinomial};
     use crate::distribution::internal::test;
-    use crate::consts::ACC;
 
     fn try_create(r: f64, p: f64) -> NegativeBinomial {
         let r = NegativeBinomial::new(r, p);

--- a/src/distribution/normal.rs
+++ b/src/distribution/normal.rs
@@ -320,7 +320,7 @@ impl std::default::Default for Normal {
 }
 
 #[rustfmt::skip]
-#[cfg(all(test, feature = "nightly"))]
+#[cfg(test)]
 mod tests {
     use crate::statistics::*;
     use crate::distribution::{ContinuousCDF, Continuous, Normal};

--- a/src/distribution/normal.rs
+++ b/src/distribution/normal.rs
@@ -325,7 +325,6 @@ mod tests {
     use crate::statistics::*;
     use crate::distribution::{ContinuousCDF, Continuous, Normal};
     use crate::distribution::internal::*;
-    use crate::consts::ACC;
 
     fn try_create(mean: f64, std_dev: f64) -> Normal {
         let n = Normal::new(mean, std_dev);

--- a/src/distribution/pareto.rs
+++ b/src/distribution/pareto.rs
@@ -328,7 +328,7 @@ impl Continuous<f64, f64> for Pareto {
 }
 
 #[rustfmt::skip]
-#[cfg(all(test, feature = "nightly"))]
+#[cfg(test)]
 mod tests {
     use crate::statistics::*;
     use crate::distribution::{ContinuousCDF, Continuous, Pareto};

--- a/src/distribution/pareto.rs
+++ b/src/distribution/pareto.rs
@@ -333,7 +333,6 @@ mod tests {
     use crate::statistics::*;
     use crate::distribution::{ContinuousCDF, Continuous, Pareto};
     use crate::distribution::internal::*;
-    use crate::consts::ACC;
 
     fn try_create(scale: f64, shape: f64) -> Pareto {
         let p = Pareto::new(scale, shape);

--- a/src/distribution/poisson.rs
+++ b/src/distribution/poisson.rs
@@ -296,7 +296,7 @@ pub fn sample_unchecked<R: Rng + ?Sized>(rng: &mut R, lambda: f64) -> f64 {
 }
 
 #[rustfmt::skip]
-#[cfg(all(test, feature = "nightly"))]
+#[cfg(test)]
 mod tests {
     use std::fmt::Debug;
     use crate::statistics::*;

--- a/src/distribution/poisson.rs
+++ b/src/distribution/poisson.rs
@@ -302,7 +302,6 @@ mod tests {
     use crate::statistics::*;
     use crate::distribution::{DiscreteCDF, Discrete, Poisson};
     use crate::distribution::internal::*;
-    use crate::consts::ACC;
 
     fn try_create(lambda: f64) -> Poisson {
         let n = Poisson::new(lambda);

--- a/src/distribution/students_t.rs
+++ b/src/distribution/students_t.rs
@@ -548,7 +548,7 @@ mod tests {
     #[test]
     fn test_pdf() {
         let pdf = |arg: f64| move |x: StudentsT| x.pdf(arg);
-        test_case(0.0, 1.0, 1.0, 0.318309886183791, pdf(0.0));
+        test_case(0.0, 1.0, 1.0, std::f64::consts::FRAC_1_PI, pdf(0.0));
         test_case(0.0, 1.0, 1.0, 0.159154943091895, pdf(1.0));
         test_case(0.0, 1.0, 1.0, 0.159154943091895, pdf(-1.0));
         test_case(0.0, 1.0, 1.0, 0.063661977236758, pdf(2.0));
@@ -768,6 +768,8 @@ mod tests {
         test(0.9, 011.0, 1.363);
         test(0.95, 011.0, 1.796);
         test(0.975, 011.0, 2.201);
+        // 2.718 is roughly equal to E
+        #[allow(clippy::approx_constant)]
         test(0.99, 011.0, 2.718);
         test(0.995, 011.0, 3.106);
         test(0.9975, 011.0, 3.497);
@@ -1152,12 +1154,12 @@ mod tests {
     #[test]
     fn test_inv_cdf_p0() {
         let d = StudentsT::new(0.0, 1.0, 12.0).unwrap();
-        assert_eq!(d.inverse_cdf(0.0), std::f64::NEG_INFINITY);
+        assert_eq!(d.inverse_cdf(0.0), f64::NEG_INFINITY);
     }
 
     #[test]
     fn test_inv_cdf_p1() {
         let d = StudentsT::new(0.0, 1.0, 12.0).unwrap();
-        assert_eq!(d.inverse_cdf(1.0), std::f64::INFINITY);
+        assert_eq!(d.inverse_cdf(1.0), f64::INFINITY);
     }
 }

--- a/src/distribution/students_t.rs
+++ b/src/distribution/students_t.rs
@@ -414,7 +414,7 @@ impl Continuous<f64, f64> for StudentsT {
     }
 }
 
-#[cfg(all(test, feature = "nightly"))]
+#[cfg(test)]
 mod tests {
     use crate::consts::ACC;
     use crate::distribution::internal::*;

--- a/src/distribution/students_t.rs
+++ b/src/distribution/students_t.rs
@@ -423,14 +423,14 @@ mod tests {
     use crate::testing_boiler;
     use std::panic;
 
-    testing_boiler!((f64, f64, f64), StudentsT);
+    testing_boiler!(location: f64, scale: f64, freedom: f64; StudentsT);
 
     #[test]
     fn test_create() {
-        try_create((0.0, 0.1, 1.0));
-        try_create((0.0, 1.0, 1.0));
-        try_create((-5.0, 1.0, 3.0));
-        try_create((10.0, 10.0, f64::INFINITY));
+        try_create(0.0, 0.1, 1.0);
+        try_create(0.0, 1.0, 1.0);
+        try_create(-5.0, 1.0, 3.0);
+        try_create(10.0, 10.0, f64::INFINITY);
     }
 
     // #[test]
@@ -441,56 +441,56 @@ mod tests {
 
     #[test]
     fn test_bad_create() {
-        bad_create_case((f64::NAN, 1.0, 1.0));
-        bad_create_case((0.0, f64::NAN, 1.0));
-        bad_create_case((0.0, 1.0, f64::NAN));
-        bad_create_case((0.0, -10.0, 1.0));
-        bad_create_case((0.0, 10.0, -1.0));
+        bad_create_case(f64::NAN, 1.0, 1.0);
+        bad_create_case(0.0, f64::NAN, 1.0);
+        bad_create_case(0.0, 1.0, f64::NAN);
+        bad_create_case(0.0, -10.0, 1.0);
+        bad_create_case(0.0, 10.0, -1.0);
     }
 
     #[test]
     fn test_mean() {
         let mean = |x: StudentsT| x.mean().unwrap();
-        test_case((0.0, 1.0, 3.0), 0.0, mean);
-        test_case((0.0, 10.0, 2.0), 0.0, mean);
-        test_case((0.0, 10.0, f64::INFINITY), 0.0, mean);
-        test_case((-5.0, 100.0, 1.5), -5.0, mean);
+        test_case(0.0, 1.0, 3.0, 0.0, mean);
+        test_case(0.0, 10.0, 2.0, 0.0, mean);
+        test_case(0.0, 10.0, f64::INFINITY, 0.0, mean);
+        test_case(-5.0, 100.0, 1.5, -5.0, mean);
         let mean = |x: StudentsT| x.mean();
-        test_none((0.0, 1.0, 1.0), mean);
-        test_none((0.0, 0.1, 1.0), mean);
-        test_none((0.0, 10.0, 1.0), mean);
-        test_none((10.0, 1.0, 1.0), mean);
-        test_none((0.0, f64::INFINITY, 1.0), mean);
+        test_none(0.0, 1.0, 1.0, mean);
+        test_none(0.0, 0.1, 1.0, mean);
+        test_none(0.0, 10.0, 1.0, mean);
+        test_none(10.0, 1.0, 1.0, mean);
+        test_none(0.0, f64::INFINITY, 1.0, mean);
     }
 
     #[test]
     #[should_panic]
     fn test_mean_freedom_lte_1() {
         let mean = |x: StudentsT| x.mean().unwrap();
-        get_value((1.0, 1.0, 0.5), mean);
+        get_value(1.0, 1.0, 0.5, mean);
     }
 
     #[test]
     fn test_variance() {
         let variance = |x: StudentsT| x.variance().unwrap();
-        test_case((0.0, 1.0, 3.0), 3.0, variance);
-        test_case((0.0, 10.0, 2.5), 500.0, variance);
-        test_case((10.0, 1.0, 2.5), 5.0, variance);
+        test_case(0.0, 1.0, 3.0, 3.0, variance);
+        test_case(0.0, 10.0, 2.5, 500.0, variance);
+        test_case(10.0, 1.0, 2.5, 5.0, variance);
         let variance = |x: StudentsT| x.variance();
-        test_none((0.0, 10.0, 2.0), variance);
-        test_none((0.0, 1.0, 1.0), variance);
-        test_none((0.0, 0.1, 1.0), variance);
-        test_none((0.0, 10.0, 1.0), variance);
-        test_none((10.0, 1.0, 1.0), variance);
-        test_none((-5.0, 100.0, 1.5), variance);
-        test_none((0.0, f64::INFINITY, 1.0), variance);
+        test_none(0.0, 10.0, 2.0, variance);
+        test_none(0.0, 1.0, 1.0, variance);
+        test_none(0.0, 0.1, 1.0, variance);
+        test_none(0.0, 10.0, 1.0, variance);
+        test_none(10.0, 1.0, 1.0, variance);
+        test_none(-5.0, 100.0, 1.5, variance);
+        test_none(0.0, f64::INFINITY, 1.0, variance);
     }
 
     #[test]
     #[should_panic]
     fn test_variance_freedom_lte1() {
         let variance = |x: StudentsT| x.variance().unwrap();
-        get_value((1.0, 1.0, 0.5), variance);
+        get_value(1.0, 1.0, 0.5, variance);
     }
 
     // TODO: valid skewness tests
@@ -498,134 +498,134 @@ mod tests {
     #[should_panic]
     fn test_skewness_freedom_lte_3() {
         let skewness = |x: StudentsT| x.skewness().unwrap();
-        get_value((1.0, 1.0, 1.0), skewness);
+        get_value(1.0, 1.0, 1.0, skewness);
     }
 
     #[test]
     fn test_mode() {
         let mode = |x: StudentsT| x.mode().unwrap();
-        test_case((0.0, 1.0, 1.0), 0.0, mode);
-        test_case((0.0, 0.1, 1.0), 0.0, mode);
-        test_case((0.0, 1.0, 3.0), 0.0, mode);
-        test_case((0.0, 10.0, 1.0), 0.0, mode);
-        test_case((0.0, 10.0, 2.0), 0.0, mode);
-        test_case((0.0, 10.0, 2.5), 0.0, mode);
-        test_case((0.0, 10.0, f64::INFINITY), 0.0, mode);
-        test_case((10.0, 1.0, 1.0), 10.0, mode);
-        test_case((10.0, 1.0, 2.5), 10.0, mode);
-        test_case((-5.0, 100.0, 1.5), -5.0, mode);
-        test_case((0.0, f64::INFINITY, 1.0), 0.0, mode);
+        test_case(0.0, 1.0, 1.0, 0.0, mode);
+        test_case(0.0, 0.1, 1.0, 0.0, mode);
+        test_case(0.0, 1.0, 3.0, 0.0, mode);
+        test_case(0.0, 10.0, 1.0, 0.0, mode);
+        test_case(0.0, 10.0, 2.0, 0.0, mode);
+        test_case(0.0, 10.0, 2.5, 0.0, mode);
+        test_case(0.0, 10.0, f64::INFINITY, 0.0, mode);
+        test_case(10.0, 1.0, 1.0, 10.0, mode);
+        test_case(10.0, 1.0, 2.5, 10.0, mode);
+        test_case(-5.0, 100.0, 1.5, -5.0, mode);
+        test_case(0.0, f64::INFINITY, 1.0, 0.0, mode);
     }
 
     #[test]
     fn test_median() {
         let median = |x: StudentsT| x.median();
-        test_case((0.0, 1.0, 1.0), 0.0, median);
-        test_case((0.0, 0.1, 1.0), 0.0, median);
-        test_case((0.0, 1.0, 3.0), 0.0, median);
-        test_case((0.0, 10.0, 1.0), 0.0, median);
-        test_case((0.0, 10.0, 2.0), 0.0, median);
-        test_case((0.0, 10.0, 2.5), 0.0, median);
-        test_case((0.0, 10.0, f64::INFINITY), 0.0, median);
-        test_case((10.0, 1.0, 1.0), 10.0, median);
-        test_case((10.0, 1.0, 2.5), 10.0, median);
-        test_case((-5.0, 100.0, 1.5), -5.0, median);
-        test_case((0.0, f64::INFINITY, 1.0), 0.0, median);
+        test_case(0.0, 1.0, 1.0, 0.0, median);
+        test_case(0.0, 0.1, 1.0, 0.0, median);
+        test_case(0.0, 1.0, 3.0, 0.0, median);
+        test_case(0.0, 10.0, 1.0, 0.0, median);
+        test_case(0.0, 10.0, 2.0, 0.0, median);
+        test_case(0.0, 10.0, 2.5, 0.0, median);
+        test_case(0.0, 10.0, f64::INFINITY, 0.0, median);
+        test_case(10.0, 1.0, 1.0, 10.0, median);
+        test_case(10.0, 1.0, 2.5, 10.0, median);
+        test_case(-5.0, 100.0, 1.5, -5.0, median);
+        test_case(0.0, f64::INFINITY, 1.0, 0.0, median);
     }
 
     #[test]
     fn test_min_max() {
         let min = |x: StudentsT| x.min();
         let max = |x: StudentsT| x.max();
-        test_case((0.0, 1.0, 1.0), f64::NEG_INFINITY, min);
-        test_case((2.5, 100.0, 1.5), f64::NEG_INFINITY, min);
-        test_case((10.0, f64::INFINITY, 3.5), f64::NEG_INFINITY, min);
-        test_case((0.0, 1.0, 1.0), f64::INFINITY, max);
-        test_case((2.5, 100.0, 1.5), f64::INFINITY, max);
-        test_case((10.0, f64::INFINITY, 5.5), f64::INFINITY, max);
+        test_case(0.0, 1.0, 1.0, f64::NEG_INFINITY, min);
+        test_case(2.5, 100.0, 1.5, f64::NEG_INFINITY, min);
+        test_case(10.0, f64::INFINITY, 3.5, f64::NEG_INFINITY, min);
+        test_case(0.0, 1.0, 1.0, f64::INFINITY, max);
+        test_case(2.5, 100.0, 1.5, f64::INFINITY, max);
+        test_case(10.0, f64::INFINITY, 5.5, f64::INFINITY, max);
     }
 
     #[test]
     fn test_pdf() {
         let pdf = |arg: f64| move |x: StudentsT| x.pdf(arg);
-        test_case((0.0, 1.0, 1.0), 0.318309886183791, pdf(0.0));
-        test_case((0.0, 1.0, 1.0), 0.159154943091895, pdf(1.0));
-        test_case((0.0, 1.0, 1.0), 0.159154943091895, pdf(-1.0));
-        test_case((0.0, 1.0, 1.0), 0.063661977236758, pdf(2.0));
-        test_case((0.0, 1.0, 1.0), 0.063661977236758, pdf(-2.0));
-        test_case((0.0, 1.0, 2.0), 0.353553390593274, pdf(0.0));
-        test_case((0.0, 1.0, 2.0), 0.192450089729875, pdf(1.0));
-        test_case((0.0, 1.0, 2.0), 0.192450089729875, pdf(-1.0));
-        test_case((0.0, 1.0, 2.0), 0.068041381743977, pdf(2.0));
-        test_case((0.0, 1.0, 2.0), 0.068041381743977, pdf(-2.0));
-        test_case((0.0, 1.0, f64::INFINITY), 0.398942280401433, pdf(0.0));
-        test_case((0.0, 1.0, f64::INFINITY), 0.241970724519143, pdf(1.0));
-        test_case((0.0, 1.0, f64::INFINITY), 0.053990966513188, pdf(2.0));
+        test_case(0.0, 1.0, 1.0, 0.318309886183791, pdf(0.0));
+        test_case(0.0, 1.0, 1.0, 0.159154943091895, pdf(1.0));
+        test_case(0.0, 1.0, 1.0, 0.159154943091895, pdf(-1.0));
+        test_case(0.0, 1.0, 1.0, 0.063661977236758, pdf(2.0));
+        test_case(0.0, 1.0, 1.0, 0.063661977236758, pdf(-2.0));
+        test_case(0.0, 1.0, 2.0, 0.353553390593274, pdf(0.0));
+        test_case(0.0, 1.0, 2.0, 0.192450089729875, pdf(1.0));
+        test_case(0.0, 1.0, 2.0, 0.192450089729875, pdf(-1.0));
+        test_case(0.0, 1.0, 2.0, 0.068041381743977, pdf(2.0));
+        test_case(0.0, 1.0, 2.0, 0.068041381743977, pdf(-2.0));
+        test_case(0.0, 1.0, f64::INFINITY, 0.398942280401433, pdf(0.0));
+        test_case(0.0, 1.0, f64::INFINITY, 0.241970724519143, pdf(1.0));
+        test_case(0.0, 1.0, f64::INFINITY, 0.053990966513188, pdf(2.0));
     }
 
     #[test]
     fn test_ln_pdf() {
         let ln_pdf = |arg: f64| move |x: StudentsT| x.ln_pdf(arg);
-        test_case((0.0, 1.0, 1.0), -1.144729885849399, ln_pdf(0.0));
-        test_case((0.0, 1.0, 1.0), -1.837877066409348, ln_pdf(1.0));
-        test_case((0.0, 1.0, 1.0), -1.837877066409348, ln_pdf(-1.0));
-        test_case((0.0, 1.0, 1.0), -2.754167798283503, ln_pdf(2.0));
-        test_case((0.0, 1.0, 1.0), -2.754167798283503, ln_pdf(-2.0));
-        test_case((0.0, 1.0, 2.0), -1.039720770839917, ln_pdf(0.0));
-        test_case((0.0, 1.0, 2.0), -1.647918433002166, ln_pdf(1.0));
-        test_case((0.0, 1.0, 2.0), -1.647918433002166, ln_pdf(-1.0));
-        test_case((0.0, 1.0, 2.0), -2.687639203842085, ln_pdf(2.0));
-        test_case((0.0, 1.0, 2.0), -2.687639203842085, ln_pdf(-2.0));
-        test_case((0.0, 1.0, f64::INFINITY), -0.918938533204672, ln_pdf(0.0));
-        test_case((0.0, 1.0, f64::INFINITY), -1.418938533204674, ln_pdf(1.0));
-        test_case((0.0, 1.0, f64::INFINITY), -2.918938533204674, ln_pdf(2.0));
+        test_case(0.0, 1.0, 1.0, -1.144729885849399, ln_pdf(0.0));
+        test_case(0.0, 1.0, 1.0, -1.837877066409348, ln_pdf(1.0));
+        test_case(0.0, 1.0, 1.0, -1.837877066409348, ln_pdf(-1.0));
+        test_case(0.0, 1.0, 1.0, -2.754167798283503, ln_pdf(2.0));
+        test_case(0.0, 1.0, 1.0, -2.754167798283503, ln_pdf(-2.0));
+        test_case(0.0, 1.0, 2.0, -1.039720770839917, ln_pdf(0.0));
+        test_case(0.0, 1.0, 2.0, -1.647918433002166, ln_pdf(1.0));
+        test_case(0.0, 1.0, 2.0, -1.647918433002166, ln_pdf(-1.0));
+        test_case(0.0, 1.0, 2.0, -2.687639203842085, ln_pdf(2.0));
+        test_case(0.0, 1.0, 2.0, -2.687639203842085, ln_pdf(-2.0));
+        test_case(0.0, 1.0, f64::INFINITY, -0.918938533204672, ln_pdf(0.0));
+        test_case(0.0, 1.0, f64::INFINITY, -1.418938533204674, ln_pdf(1.0));
+        test_case(0.0, 1.0, f64::INFINITY, -2.918938533204674, ln_pdf(2.0));
     }
 
     #[test]
     fn test_cdf() {
         let cdf = |arg: f64| move |x: StudentsT| x.cdf(arg);
-        test_case((0.0, 1.0, 1.0), 0.5, cdf(0.0));
-        test_case((0.0, 1.0, 1.0), 0.75, cdf(1.0));
-        test_case((0.0, 1.0, 1.0), 0.25, cdf(-1.0));
-        test_case((0.0, 1.0, 1.0), 0.852416382349567, cdf(2.0));
-        test_case((0.0, 1.0, 1.0), 0.147583617650433, cdf(-2.0));
-        test_case((0.0, 1.0, 2.0), 0.5, cdf(0.0));
-        test_case((0.0, 1.0, 2.0), 0.788675134594813, cdf(1.0));
-        test_case((0.0, 1.0, 2.0), 0.211324865405187, cdf(-1.0));
-        test_case((0.0, 1.0, 2.0), 0.908248290463863, cdf(2.0));
-        test_case((0.0, 1.0, 2.0), 0.091751709536137, cdf(-2.0));
-        test_case((0.0, 1.0, f64::INFINITY), 0.5, cdf(0.0));
+        test_case(0.0, 1.0, 1.0, 0.5, cdf(0.0));
+        test_case(0.0, 1.0, 1.0, 0.75, cdf(1.0));
+        test_case(0.0, 1.0, 1.0, 0.25, cdf(-1.0));
+        test_case(0.0, 1.0, 1.0, 0.852416382349567, cdf(2.0));
+        test_case(0.0, 1.0, 1.0, 0.147583617650433, cdf(-2.0));
+        test_case(0.0, 1.0, 2.0, 0.5, cdf(0.0));
+        test_case(0.0, 1.0, 2.0, 0.788675134594813, cdf(1.0));
+        test_case(0.0, 1.0, 2.0, 0.211324865405187, cdf(-1.0));
+        test_case(0.0, 1.0, 2.0, 0.908248290463863, cdf(2.0));
+        test_case(0.0, 1.0, 2.0, 0.091751709536137, cdf(-2.0));
+        test_case(0.0, 1.0, f64::INFINITY, 0.5, cdf(0.0));
 
         // TODO: these are curiously low accuracy and should be re-examined
-        test_case((0.0, 1.0, f64::INFINITY), 0.841344746068543, cdf(1.0));
-        test_case((0.0, 1.0, f64::INFINITY), 0.977249868051821, cdf(2.0));
+        test_case(0.0, 1.0, f64::INFINITY, 0.841344746068543, cdf(1.0));
+        test_case(0.0, 1.0, f64::INFINITY, 0.977249868051821, cdf(2.0));
     }
 
     #[test]
     fn test_sf() {
         let sf = |arg: f64| move |x: StudentsT| x.sf(arg);
-        test_case((0.0, 1.0, 1.0), 0.5, sf(0.0));
-        test_case((0.0, 1.0, 1.0), 0.25, sf(1.0));
-        test_case((0.0, 1.0, 1.0), 0.75, sf(-1.0));
-        test_case((0.0, 1.0, 1.0), 0.147583617650433, sf(2.0));
-        test_case((0.0, 1.0, 1.0), 0.852416382349566, sf(-2.0));
-        test_case((0.0, 1.0, 2.0), 0.5, sf(0.0));
-        test_case((0.0, 1.0, 2.0), 0.211324865405186, sf(1.0));
-        test_case((0.0, 1.0, 2.0), 0.788675134594813, sf(-1.0));
-        test_case((0.0, 1.0, 2.0), 0.091751709536137, sf(2.0));
-        test_case((0.0, 1.0, 2.0), 0.908248290463862, sf(-2.0));
-        test_case((0.0, 1.0, f64::INFINITY), 0.5, sf(0.0));
+        test_case(0.0, 1.0, 1.0, 0.5, sf(0.0));
+        test_case(0.0, 1.0, 1.0, 0.25, sf(1.0));
+        test_case(0.0, 1.0, 1.0, 0.75, sf(-1.0));
+        test_case(0.0, 1.0, 1.0, 0.147583617650433, sf(2.0));
+        test_case(0.0, 1.0, 1.0, 0.852416382349566, sf(-2.0));
+        test_case(0.0, 1.0, 2.0, 0.5, sf(0.0));
+        test_case(0.0, 1.0, 2.0, 0.211324865405186, sf(1.0));
+        test_case(0.0, 1.0, 2.0, 0.788675134594813, sf(-1.0));
+        test_case(0.0, 1.0, 2.0, 0.091751709536137, sf(2.0));
+        test_case(0.0, 1.0, 2.0, 0.908248290463862, sf(-2.0));
+        test_case(0.0, 1.0, f64::INFINITY, 0.5, sf(0.0));
 
         // TODO: these are curiously low accuracy and should be re-examined
-        test_case((0.0, 1.0, f64::INFINITY), 0.158655253945057, sf(1.0));
-        test_case((0.0, 1.0, f64::INFINITY), 0.022750131947162, sf(2.0));
+        test_case(0.0, 1.0, f64::INFINITY, 0.158655253945057, sf(1.0));
+        test_case(0.0, 1.0, f64::INFINITY, 0.022750131947162, sf(2.0));
     }
 
     #[test]
     fn test_continuous() {
-        test::check_continuous_distribution(&try_create((0.0, 1.0, 3.0)), -30.0, 30.0);
-        test::check_continuous_distribution(&try_create((0.0, 1.0, 10.0)), -10.0, 10.0);
-        test::check_continuous_distribution(&try_create((20.0, 0.5, 10.0)), 10.0, 30.0);
+        test::check_continuous_distribution(&try_create(0.0, 1.0, 3.0), -30.0, 30.0);
+        test::check_continuous_distribution(&try_create(0.0, 1.0, 10.0), -10.0, 10.0);
+        test::check_continuous_distribution(&try_create(20.0, 0.5, 10.0), 10.0, 30.0);
     }
 
     #[test]

--- a/src/distribution/triangular.rs
+++ b/src/distribution/triangular.rs
@@ -311,7 +311,7 @@ fn sample_unchecked<R: Rng + ?Sized>(rng: &mut R, min: f64, max: f64, mode: f64)
 }
 
 #[rustfmt::skip]
-#[cfg(all(test, feature = "nightly"))]
+#[cfg(test)]
 mod tests {
     use std::fmt::Debug;
     use crate::statistics::*;

--- a/src/distribution/triangular.rs
+++ b/src/distribution/triangular.rs
@@ -317,7 +317,6 @@ mod tests {
     use crate::statistics::*;
     use crate::distribution::{ContinuousCDF, Continuous, Triangular};
     use crate::distribution::internal::*;
-    use crate::consts::ACC;
 
     fn try_create(min: f64, max: f64, mode: f64) -> Triangular {
         let n = Triangular::new(min, max, mode);

--- a/src/distribution/uniform.rs
+++ b/src/distribution/uniform.rs
@@ -255,7 +255,7 @@ impl Continuous<f64, f64> for Uniform {
 }
 
 #[rustfmt::skip]
-#[cfg(all(test, feature = "nightly"))]
+#[cfg(test)]
 mod tests {
     use crate::statistics::*;
     use crate::distribution::{ContinuousCDF, Continuous, Uniform};

--- a/src/distribution/uniform.rs
+++ b/src/distribution/uniform.rs
@@ -260,7 +260,6 @@ mod tests {
     use crate::statistics::*;
     use crate::distribution::{ContinuousCDF, Continuous, Uniform};
     use crate::distribution::internal::*;
-    use crate::consts::ACC;
 
     fn try_create(min: f64, max: f64) -> Uniform {
         let n = Uniform::new(min, max);

--- a/src/distribution/weibull.rs
+++ b/src/distribution/weibull.rs
@@ -325,7 +325,7 @@ impl Continuous<f64, f64> for Weibull {
 }
 
 #[rustfmt::skip]
-#[cfg(all(test, feature = "nightly"))]
+#[cfg(test)]
 mod tests {
     use crate::statistics::*;
     use crate::distribution::{ContinuousCDF, Continuous, Weibull};

--- a/src/distribution/weibull.rs
+++ b/src/distribution/weibull.rs
@@ -330,7 +330,6 @@ mod tests {
     use crate::statistics::*;
     use crate::distribution::{ContinuousCDF, Continuous, Weibull};
     use crate::distribution::internal::*;
-    use crate::consts::ACC;
 
     fn try_create(shape: f64, scale: f64) -> Weibull {
         let n = Weibull::new(shape, scale);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,8 +49,6 @@
 #![allow(clippy::many_single_char_names)]
 #![allow(unused_imports)]
 #![forbid(unsafe_code)]
-#![cfg_attr(all(test, feature = "nightly"), feature(unboxed_closures))]
-#![cfg_attr(all(test, feature = "nightly"), feature(fn_traits))]
 
 #[macro_use]
 extern crate approx;


### PR DESCRIPTION
Addresses part of #233.

This makes the macro a bit more complicated but removes the need for the `fn_traits` feature.

Instead of 
```rs
testing_boiler!((f64, f64), Beta);

#[test]
fn some_test() {
    let arg = (1.0, 2.0);
    try_create(arg);
}
```

it's now

```rs
testing_boiler!(a: f64, b: f64; Beta);

#[test]
fn some_test() {
    let arg_a = 1.0;
    let arg_b = 2.0;
    try_create(arg_a, arg_b);
}
```