### PR TITLE
Make almost_eq return false if a and/or b is NaN

### DIFF
--- a/src/prec.rs
+++ b/src/prec.rs
@@ -12,6 +12,9 @@ pub const DEFAULT_F64_ACC: f64 = 0.0000000000000011102230246251565;
 /// Compares if two floats are close via `approx::abs_diff_eq`
 /// using a maximum absolute difference (epsilon) of `acc`.
 pub fn almost_eq(a: f64, b: f64, acc: f64) -> bool {
+    if a.is_infinite() && b.is_infinite() {
+        return true;
+    }
     a.abs_diff_eq(&b, acc)
 }
 

--- a/src/prec.rs
+++ b/src/prec.rs
@@ -1,5 +1,7 @@
 //! Provides utility functions for working with floating point precision
 
+use approx::AbsDiffEq;
+
 /// Standard epsilon, maximum relative precision of IEEE 754 double-precision
 /// floating point numbers (64 bit) e.g. `2^-53`
 pub const F64_PREC: f64 = 0.00000000000000011102230246251565;
@@ -7,23 +9,10 @@ pub const F64_PREC: f64 = 0.00000000000000011102230246251565;
 /// Default accuracy for `f64`, equivalent to `0.0 * F64_PREC`
 pub const DEFAULT_F64_ACC: f64 = 0.0000000000000011102230246251565;
 
-/// Returns true if `a` and `b `are within `acc` of each other.
-/// If `a` or `b` are infinite, returns `true` only if both are
-/// infinite and similarly signed. Always returns `false` if
-/// either number is a `NAN`.
+/// Compares if two floats are close via `approx::abs_diff_eq`
+/// using a maximum absolute difference (epsilon) of `acc`.
 pub fn almost_eq(a: f64, b: f64, acc: f64) -> bool {
-    // only true if a and b are infinite with same
-    // sign
-    if a.is_infinite() || b.is_infinite() {
-        return a == b;
-    }
-
-    // NANs are never equal
-    if a.is_nan() && b.is_nan() {
-        return false;
-    }
-
-    (a - b).abs() < acc
+    a.abs_diff_eq(&b, acc)
 }
 
 /// Compares if two floats are close via `approx::relative_eq!`


### PR DESCRIPTION
I feel like this might have been a typo because the docs say that `almost_eq` always returns `false` if either number is NaN. It also seems correct that `almost_eq(NaN, x)` is always false.
