### PR TITLE
Fix fisher test

### DIFF
--- a/src/stats_tests/fisher.rs
+++ b/src/stats_tests/fisher.rs
@@ -99,7 +99,8 @@ fn binary_search(
 
 /// Perform a Fisher exact test on a 2x2 contingency table.
 /// Based on scipy's fisher test: https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.fisher_exact.html#scipy-stats-fisher-exact
-/// Returns the odds ratio and p_value
+/// Expects a table in row-major order
+/// Returns the [odds ratio](https://en.wikipedia.org/wiki/Odds_ratio) and p_value
 /// # Examples
 ///
 /// ```
@@ -132,6 +133,7 @@ pub fn fishers_exact_with_odds_ratio(
 
 /// Perform a Fisher exact test on a 2x2 contingency table.
 /// Based on scipy's fisher test: https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.fisher_exact.html#scipy-stats-fisher-exact
+/// Expects a table in row-major order
 /// Returns only the p_value
 /// # Examples
 ///

--- a/src/stats_tests/fisher.rs
+++ b/src/stats_tests/fisher.rs
@@ -342,6 +342,16 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn test_fishers_exact_for_trivial() {
+        let cases = [[0, 0, 1, 2], [1, 2, 0, 0], [1, 0, 2, 0], [0, 1, 0, 2]];
+
+        for table in cases.iter() {
+            assert_eq!(fishers_exact(table, Alternative::Less).unwrap(), 1.0)
+        }
+    }
+
     #[test]
     fn test_fishers_exact_with_odds() {
         let table = [3, 5, 4, 50];

--- a/src/stats_tests/fisher.rs
+++ b/src/stats_tests/fisher.rs
@@ -109,8 +109,8 @@ fn binary_search(
 /// # Examples
 ///
 /// ```
-/// use statrs::statis_tests::fishers_exact;
-/// use statrs::statis_tests::Alternative;
+/// use statrs::stats_tests::fishers_exact_with_odds_ratio;
+/// use statrs::stats_tests::Alternative;
 /// let table = [3, 5, 4, 50];
 /// let (odds_ratio, p_value) = fishers_exact_with_odds_ratio(&table, Alternative::Less).unwrap();
 /// ```
@@ -142,8 +142,8 @@ pub fn fishers_exact_with_odds_ratio(
 /// # Examples
 ///
 /// ```
-/// use statrs::statis_tests::fishers_exact;
-/// use statrs::statis_tests::Alternative;
+/// use statrs::stats_tests::fishers_exact;
+/// use statrs::stats_tests::Alternative;
 /// let table = [3, 5, 4, 50];
 /// let p_value = fishers_exact(&table, Alternative::Less).unwrap();
 /// ```
@@ -209,9 +209,8 @@ pub fn fishers_exact(table: &[u64; 4], alternative: Alternative) -> Result<f64, 
 
 #[cfg(test)]
 mod tests {
-    use super::fishers_exact;
+    use super::*;
     use crate::prec;
-    use crate::stats_tests::fisher::{fishers_exact_with_odds_ratio, Alternative};
 
     /// Test fishers_exact by comparing against values from scipy.
     #[test]

--- a/src/stats_tests/fisher.rs
+++ b/src/stats_tests/fisher.rs
@@ -113,10 +113,11 @@ pub fn fishers_exact_with_odds_ratio(
     table: &[u64; 4],
     alternative: Alternative,
 ) -> Result<(f64, f64), StatsError> {
-    // Calculate fisher's exact test with the odds ratio
-    if (table[0] == 0 && table[2] == 0) || (table[1] == 0 && table[3] == 0) {
-        // If both values in a row or column are zero, p-value is 1 and odds ratio is NaN.
-        return Ok((f64::NAN, 1.0));
+    // If both values in a row or column are zero, p-value is 1 and odds ratio is NaN.
+    match table {
+        [0, _, 0, _] | [_, 0, _, 0] => return Ok((f64::NAN, 1.0)), // both 0 in a row
+        [0, 0, _, _] | [_, _, 0, 0] => return Ok((f64::NAN, 1.0)), // both 0 in a column
+        _ => (),                                                   // continue
     }
 
     let odds_ratio = {
@@ -145,8 +146,10 @@ pub fn fishers_exact_with_odds_ratio(
 /// ```
 pub fn fishers_exact(table: &[u64; 4], alternative: Alternative) -> Result<f64, StatsError> {
     // If both values in a row or column are zero, the p-value is 1 and the odds ratio is NaN.
-    if (table[0] == 0 && table[2] == 0) || (table[1] == 0 && table[3] == 0) {
-        return Ok(1.0);
+    match table {
+        [0, _, 0, _] | [_, 0, _, 0] => return Ok(1.0), // both 0 in a row
+        [0, 0, _, _] | [_, _, 0, 0] => return Ok(1.0), // both 0 in a column
+        _ => (),                                       // continue
     }
 
     let n1 = table[0] + table[1];

--- a/src/stats_tests/fisher.rs
+++ b/src/stats_tests/fisher.rs
@@ -1,12 +1,6 @@
+use super::Alternative;
 use crate::distribution::{Discrete, DiscreteCDF, Hypergeometric};
 use crate::StatsError;
-
-#[derive(Debug, Copy, Clone)]
-pub enum Alternative {
-    TwoSided,
-    Less,
-    Greater,
-}
 
 const EPSILON: f64 = 1.0 - 1e-4;
 

--- a/src/stats_tests/mod.rs
+++ b/src/stats_tests/mod.rs
@@ -1,4 +1,10 @@
 pub mod fisher;
 
-pub use fisher::Alternative;
+#[derive(Debug, Copy, Clone)]
+pub enum Alternative {
+    TwoSided,
+    Less,
+    Greater,
+}
+
 pub use fisher::{fishers_exact, fishers_exact_with_odds_ratio};

--- a/src/stats_tests/mod.rs
+++ b/src/stats_tests/mod.rs
@@ -1,1 +1,4 @@
 pub mod fisher;
+
+pub use fisher::Alternative;
+pub use fisher::{fishers_exact, fishers_exact_with_odds_ratio};

--- a/src/stats_tests/mod.rs
+++ b/src/stats_tests/mod.rs
@@ -1,9 +1,16 @@
 pub mod fisher;
 
+/// Specifies an [alternative hypothesis](https://en.wikipedia.org/wiki/Alternative_hypothesis)
 #[derive(Debug, Copy, Clone)]
 pub enum Alternative {
+    #[doc(alias = "two-tailed")]
+    #[doc(alias = "two tailed")]
     TwoSided,
+    #[doc(alias = "one-tailed")]
+    #[doc(alias = "one tailed")]
     Less,
+    #[doc(alias = "one-tailed")]
+    #[doc(alias = "one tailed")]
     Greater,
 }
 


### PR DESCRIPTION
#167 introduced fisher exact tests

This adds some minor docs, most notably, specifying that the expected table, provided as a slice of floats (i.e. flat), is row-major.

Also fixes a "bug" for short circuiting the evaluation of the test when both values in either row are 0's. Full evaluation is exactly "1.0f64" as well, but pushing for consistency here.