### PR TITLE
Replace `is_zero(x)` with `x == 0.0`

### DIFF
--- a/src/distribution/beta.rs
+++ b/src/distribution/beta.rs
@@ -1,6 +1,5 @@
 use crate::distribution::{Continuous, ContinuousCDF};
 use crate::function::{beta, gamma};
-use crate::is_zero;
 use crate::statistics::*;
 use crate::{Result, StatsError};
 use rand::Rng;
@@ -339,7 +338,7 @@ impl Continuous<f64, f64> for Beta {
                 0.0
             }
         } else if self.shape_b.is_infinite() {
-            if is_zero(x) {
+            if x == 0.0 {
                 f64::INFINITY
             } else {
                 0.0
@@ -377,7 +376,7 @@ impl Continuous<f64, f64> for Beta {
                 f64::NEG_INFINITY
             }
         } else if self.shape_b.is_infinite() {
-            if is_zero(x) {
+            if x == 0.0 {
                 f64::INFINITY
             } else {
                 f64::NEG_INFINITY
@@ -388,9 +387,9 @@ impl Continuous<f64, f64> for Beta {
             let aa = gamma::ln_gamma(self.shape_a + self.shape_b)
                 - gamma::ln_gamma(self.shape_a)
                 - gamma::ln_gamma(self.shape_b);
-            let bb = if ulps_eq!(self.shape_a, 1.0) && is_zero(x) {
+            let bb = if ulps_eq!(self.shape_a, 1.0) && x == 0.0 {
                 0.0
-            } else if is_zero(x) {
+            } else if x == 0.0 {
                 f64::NEG_INFINITY
             } else {
                 (self.shape_a - 1.0) * x.ln()

--- a/src/distribution/binomial.rs
+++ b/src/distribution/binomial.rs
@@ -1,6 +1,5 @@
 use crate::distribution::{Discrete, DiscreteCDF};
 use crate::function::{beta, factorial};
-use crate::is_zero;
 use crate::statistics::*;
 use crate::{Result, StatsError};
 use rand::Rng;
@@ -207,7 +206,7 @@ impl Distribution<f64> for Binomial {
     /// (1 / 2) * ln (2 * π * e * n * p * (1 - p))
     /// ```
     fn entropy(&self) -> Option<f64> {
-        let entr = if is_zero(self.p) || ulps_eq!(self.p, 1.0) {
+        let entr = if self.p == 0.0 || ulps_eq!(self.p, 1.0) {
             0.0
         } else {
             (0..self.n + 1).fold(0.0, |acc, x| {
@@ -252,7 +251,7 @@ impl Mode<Option<u64>> for Binomial {
     /// floor((n + 1) * p)
     /// ```
     fn mode(&self) -> Option<u64> {
-        let mode = if is_zero(self.p) {
+        let mode = if self.p == 0.0 {
             0
         } else if ulps_eq!(self.p, 1.0) {
             self.n
@@ -275,7 +274,7 @@ impl Discrete<u64, f64> for Binomial {
     fn pmf(&self, x: u64) -> f64 {
         if x > self.n {
             0.0
-        } else if is_zero(self.p) {
+        } else if self.p == 0.0 {
             if x == 0 {
                 1.0
             } else {
@@ -306,7 +305,7 @@ impl Discrete<u64, f64> for Binomial {
     fn ln_pmf(&self, x: u64) -> f64 {
         if x > self.n {
             f64::NEG_INFINITY
-        } else if is_zero(self.p) {
+        } else if self.p == 0.0 {
             if x == 0 {
                 0.0
             } else {

--- a/src/distribution/students_t.rs
+++ b/src/distribution/students_t.rs
@@ -1,6 +1,5 @@
 use crate::distribution::{Continuous, ContinuousCDF};
 use crate::function::{beta, gamma};
-use crate::is_zero;
 use crate::statistics::*;
 use crate::{Result, StatsError};
 use rand::Rng;

--- a/src/distribution/weibull.rs
+++ b/src/distribution/weibull.rs
@@ -1,6 +1,5 @@
 use crate::distribution::{Continuous, ContinuousCDF};
 use crate::function::gamma;
-use crate::is_zero;
 use crate::statistics::*;
 use crate::{consts, Result, StatsError};
 use rand::Rng;
@@ -293,7 +292,7 @@ impl Continuous<f64, f64> for Weibull {
     fn pdf(&self, x: f64) -> f64 {
         if x < 0.0 {
             0.0
-        } else if is_zero(x) && ulps_eq!(self.shape, 1.0) {
+        } else if x == 0.0 && ulps_eq!(self.shape, 1.0) {
             1.0 / self.scale
         } else if x.is_infinite() {
             0.0
@@ -318,7 +317,7 @@ impl Continuous<f64, f64> for Weibull {
     fn ln_pdf(&self, x: f64) -> f64 {
         if x < 0.0 {
             f64::NEG_INFINITY
-        } else if is_zero(x) && ulps_eq!(self.shape, 1.0) {
+        } else if x == 0.0 && ulps_eq!(self.shape, 1.0) {
             0.0 - self.scale.ln()
         } else if x.is_infinite() {
             f64::NEG_INFINITY

--- a/src/function/beta.rs
+++ b/src/function/beta.rs
@@ -3,7 +3,6 @@
 
 use crate::error::StatsError;
 use crate::function::gamma;
-use crate::is_zero;
 use crate::prec;
 use crate::Result;
 use std::f64;
@@ -118,7 +117,7 @@ pub fn checked_beta_reg(a: f64, b: f64, x: f64) -> Result<f64> {
     } else if !(0.0..=1.0).contains(&x) {
         Err(StatsError::ArgIntervalIncl("x", 0.0, 1.0))
     } else {
-        let bt = if is_zero(x) || ulps_eq!(x, 1.0) {
+        let bt = if x == 0.0 || ulps_eq!(x, 1.0) {
             0.0
         } else {
             (gamma::ln_gamma(a + b) - gamma::ln_gamma(a) - gamma::ln_gamma(b)

--- a/src/function/erf.rs
+++ b/src/function/erf.rs
@@ -2,7 +2,6 @@
 //! related functions
 
 use crate::function::evaluate;
-use crate::is_zero;
 use std::f64;
 
 /// `erf` calculates the error function at `x`.
@@ -13,7 +12,7 @@ pub fn erf(x: f64) -> f64 {
         1.0
     } else if x <= 0.0 && x.is_infinite() {
         -1.0
-    } else if is_zero(x) {
+    } else if x == 0.0 {
         0.0
     } else {
         erf_impl(x, false)

--- a/src/function/gamma.rs
+++ b/src/function/gamma.rs
@@ -3,7 +3,6 @@
 
 use crate::consts;
 use crate::error::StatsError;
-use crate::is_zero;
 use crate::prec;
 use crate::Result;
 use std::f64;
@@ -216,7 +215,7 @@ pub fn checked_gamma_ur(a: f64, x: f64) -> Result<f64> {
             qkm1 *= big_inv;
         }
 
-        if !is_zero(qk) {
+        if qk != 0.0 {
             let r = pk / qk;
             let t = ((ans - r) / r).abs();
             ans = r;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,12 +77,6 @@ pub mod stats_tests;
 
 mod error;
 
-// function to silence clippy on the special case when comparing to zero.
-#[inline(always)]
-pub(crate) fn is_zero(x: f64) -> bool {
-    ulps_eq!(x, 0.0, max_ulps = 0)
-}
-
 pub use crate::error::StatsError;
 
 /// Result type for the statrs library package that returns


### PR DESCRIPTION
```rs
fn is_zero(x: f64) -> bool {
    ulps_eq!(x, 0.0, max_ulps = 0)
}
```

[turns into](https://docs.rs/approx/latest/src/approx/macros.rs.html#61-68)

```rs
::approx::Ulps::default().max_ulps(0).eq(x, 0.0)
```

[which turns into](https://docs.rs/approx/latest/src/approx/ulps_eq.rs.html#34-71)

```rs
if (x - 0.0).abs() <= f64::EPSILON {
  return true;
}

if x.signum() != 0.0.signum() {
  return false;
}

x.to_bits() - 0.0.to_bits() == 0
```

The actual code is not quite as clear as this, it took me a few minutes to find the relevant places and shorten it to this.

`is_zero` [was introduced](https://github.com/statrs-dev/statrs/commit/b186804e9a61b2023d72ce0cb3a06feb9a06c5dc) in order to silence clippy warnings/errors and was a 1:1 replacement for `x == 0.0`. 

I would argue that `is_zero` is unnecessarily complicated, not transparent and possibly incorrect (one example: `0.0` == `-0.0` evaluates to `true` while `is_zero(-0.0)` will evaluate to `false`) and was not the right solution to the clippy warnings in the first place.