### PR TITLE
Remove unused imports

### DIFF
--- a/src/distribution/beta.rs
+++ b/src/distribution/beta.rs
@@ -412,7 +412,6 @@ impl Continuous<f64, f64> for Beta {
 mod tests {
     use super::*;
     use super::super::internal::*;
-    use crate::statistics::*;
     use crate::testing_boiler;
 
     testing_boiler!(a: f64, b: f64; Beta);

--- a/src/distribution/dirac.rs
+++ b/src/distribution/dirac.rs
@@ -1,4 +1,4 @@
-use crate::distribution::{Continuous, ContinuousCDF};
+use crate::distribution::ContinuousCDF;
 use crate::statistics::*;
 use crate::{Result, StatsError};
 use rand::Rng;
@@ -194,7 +194,7 @@ impl Mode<Option<f64>> for Dirac {
 #[cfg(test)]
 mod tests {
     use crate::statistics::*;
-    use crate::distribution::{ContinuousCDF, Continuous, Dirac};
+    use crate::distribution::{ContinuousCDF, Dirac};
 
     fn try_create(v: f64) -> Dirac {
         let d = Dirac::new(v);

--- a/src/distribution/dirichlet.rs
+++ b/src/distribution/dirichlet.rs
@@ -4,9 +4,6 @@ use crate::statistics::*;
 use crate::{prec, Result, StatsError};
 use nalgebra::DMatrix;
 use nalgebra::DVector;
-use nalgebra::{
-    base::allocator::Allocator, base::dimension::DimName, DefaultAllocator, Dim, DimMin, U1,
-};
 use rand::Rng;
 use std::f64;
 
@@ -310,9 +307,6 @@ fn is_valid_alpha(a: &[f64]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nalgebra::{DVector};
-    use crate::function::gamma;
-    use crate::statistics::*;
     use crate::distribution::{Continuous, Dirichlet};
 
     #[test]

--- a/src/distribution/empirical.rs
+++ b/src/distribution/empirical.rs
@@ -1,7 +1,6 @@
-use crate::distribution::{Continuous, ContinuousCDF, Uniform};
+use crate::distribution::{ContinuousCDF, Uniform};
 use crate::statistics::*;
-use crate::{Result, StatsError};
-use ::num_traits::float::Float;
+use crate::Result;
 use core::cmp::Ordering;
 use rand::Rng;
 use std::collections::BTreeMap;

--- a/src/distribution/internal.rs
+++ b/src/distribution/internal.rs
@@ -1,4 +1,4 @@
-use num_traits::{Bounded, Float, Num};
+use num_traits::Num;
 
 /// Returns true if there are no elements in `x` in `arr`
 /// such that `x <= 0.0` or `x` is `f64::NAN` and `sum(arr) > 0.0`.

--- a/src/distribution/mod.rs
+++ b/src/distribution/mod.rs
@@ -2,8 +2,8 @@
 //! and provides
 //! concrete implementations for a variety of distributions.
 use super::statistics::{Max, Min};
-use ::num_traits::{Bounded, Float, Num};
-use num_traits::{NumAssign, NumAssignOps, NumAssignRef};
+use ::num_traits::{Float, Num};
+use num_traits::NumAssignOps;
 
 pub use self::bernoulli::Bernoulli;
 pub use self::beta::Beta;
@@ -70,8 +70,6 @@ mod uniform;
 mod weibull;
 mod ziggurat;
 mod ziggurat_tables;
-
-use crate::Result;
 
 /// The `ContinuousCDF` trait is used to specify an interface for univariate
 /// distributions for which cdf float arguments are sensible.

--- a/src/distribution/multivariate_normal.rs
+++ b/src/distribution/multivariate_normal.rs
@@ -2,10 +2,7 @@ use crate::distribution::Continuous;
 use crate::distribution::Normal;
 use crate::statistics::{Max, MeanN, Min, Mode, VarianceN};
 use crate::{Result, StatsError};
-use nalgebra::{
-    base::allocator::Allocator, Cholesky, Const, DMatrix, DVector, DefaultAllocator, Dim, DimMin,
-    Dyn, OMatrix, OVector,
-};
+use nalgebra::{Cholesky, Const, DMatrix, DVector, Dim, DimMin, Dyn, OMatrix, OVector};
 use rand::Rng;
 use std::f64;
 use std::f64::consts::{E, PI};

--- a/src/distribution/students_t.rs
+++ b/src/distribution/students_t.rs
@@ -1,6 +1,5 @@
 use crate::distribution::{Continuous, ContinuousCDF};
 use crate::function::{beta, gamma};
-use crate::is_zero;
 use crate::statistics::*;
 use crate::{Result, StatsError};
 use rand::Rng;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,6 @@
 #![crate_name = "statrs"]
 #![allow(clippy::excessive_precision)]
 #![allow(clippy::many_single_char_names)]
-#![allow(unused_imports)]
 #![forbid(unsafe_code)]
 
 #[macro_use]

--- a/src/statistics/iter_statistics.rs
+++ b/src/statistics/iter_statistics.rs
@@ -244,10 +244,6 @@ where
 #[cfg(test)]
 mod tests {
     use std::f64::consts;
-    use rand::rngs::StdRng;
-    use rand::SeedableRng;
-    use rand::distributions::Distribution;
-    use crate::distribution::Normal;
     use crate::statistics::Statistics;
     use crate::generate::{InfinitePeriodic, InfiniteSinusoidal};
 

--- a/src/statistics/mod.rs
+++ b/src/statistics/mod.rs
@@ -1,6 +1,5 @@
 //! Provides traits for statistical computation
 
-pub use self::iter_statistics::*;
 pub use self::order_statistics::*;
 pub use self::slice_statistics::*;
 pub use self::statistics::*;

--- a/src/statistics/traits.rs
+++ b/src/statistics/traits.rs
@@ -1,6 +1,3 @@
-use ::nalgebra::{
-    base::allocator::Allocator, base::dimension::DimName, DefaultAllocator, Dim, DimMin, U1,
-};
 use ::num_traits::float::Float;
 
 const STEPS: usize = 1_000;


### PR DESCRIPTION
I don't think there's a good reason to allow this in the entire crate. There weren't many unused imports to remove anyways, and if necessary it can always be re-allowed for specific files or modules.