### PR TITLE
Implement concrete Error types for each distribution's `new` function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,8 @@ anyhow = "1.0"
 version = "0.32"
 default-features = false
 features = ["macros"]
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+# Set by cargo-llvm-cov when running on nightly
+check-cfg = ['cfg(coverage_nightly)']

--- a/src/distribution/bernoulli.rs
+++ b/src/distribution/bernoulli.rs
@@ -265,11 +265,11 @@ impl Discrete<u64, f64> for Bernoulli {
 #[rustfmt::skip]
 #[cfg(test)]
 mod testing {
-    use crate::distribution::DiscreteCDF;
+    use super::*;
+    use crate::StatsError;
     use crate::testing_boiler;
-    use super::Bernoulli;
 
-    testing_boiler!(p: f64; Bernoulli);
+    testing_boiler!(p: f64; Bernoulli; StatsError);
 
     #[test]
     fn test_create() {

--- a/src/distribution/bernoulli.rs
+++ b/src/distribution/bernoulli.rs
@@ -1,6 +1,5 @@
-use crate::distribution::{Binomial, Discrete, DiscreteCDF};
+use crate::distribution::{Binomial, BinomialError, Discrete, DiscreteCDF};
 use crate::statistics::*;
-use crate::Result;
 use rand::Rng;
 
 /// Implements the
@@ -45,7 +44,7 @@ impl Bernoulli {
     /// result = Bernoulli::new(-0.5);
     /// assert!(result.is_err());
     /// ```
-    pub fn new(p: f64) -> Result<Bernoulli> {
+    pub fn new(p: f64) -> Result<Bernoulli, BinomialError> {
         Binomial::new(p, 1).map(|b| Bernoulli { b })
     }
 
@@ -266,10 +265,9 @@ impl Discrete<u64, f64> for Bernoulli {
 #[cfg(test)]
 mod testing {
     use super::*;
-    use crate::StatsError;
     use crate::testing_boiler;
 
-    testing_boiler!(p: f64; Bernoulli; StatsError);
+    testing_boiler!(p: f64; Bernoulli; BinomialError);
 
     #[test]
     fn test_create() {

--- a/src/distribution/beta.rs
+++ b/src/distribution/beta.rs
@@ -433,7 +433,7 @@ mod tests {
     use super::super::internal::*;
     use crate::testing_boiler;
 
-    testing_boiler!(a: f64, b: f64; Beta);
+    testing_boiler!(a: f64, b: f64; Beta; StatsError);
 
     #[test]
     fn test_create() {

--- a/src/distribution/beta.rs
+++ b/src/distribution/beta.rs
@@ -38,6 +38,7 @@ pub enum BetaError {
 }
 
 impl std::fmt::Display for BetaError {
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             BetaError::ShapeAInvalid => write!(f, "Shape A is NaN, zero or negative"),

--- a/src/distribution/binomial.rs
+++ b/src/distribution/binomial.rs
@@ -1,7 +1,6 @@
 use crate::distribution::{Discrete, DiscreteCDF};
 use crate::function::{beta, factorial};
 use crate::statistics::*;
-use crate::{Result, StatsError};
 use rand::Rng;
 use std::f64;
 
@@ -26,6 +25,24 @@ pub struct Binomial {
     n: u64,
 }
 
+/// Represents the errors that can occur when creating a [`Binomial`].
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
+#[non_exhaustive]
+pub enum BinomialError {
+    /// The probability is NaN or not in `[0, 1]`.
+    ProbabilityInvalid,
+}
+
+impl std::fmt::Display for BinomialError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            BinomialError::ProbabilityInvalid => write!(f, "Probability is NaN or not in [0, 1]"),
+        }
+    }
+}
+
+impl std::error::Error for BinomialError {}
+
 impl Binomial {
     /// Constructs a new binomial distribution
     /// with a given `p` probability of success of `n`
@@ -47,9 +64,9 @@ impl Binomial {
     /// result = Binomial::new(-0.5, 5);
     /// assert!(result.is_err());
     /// ```
-    pub fn new(p: f64, n: u64) -> Result<Binomial> {
+    pub fn new(p: f64, n: u64) -> Result<Binomial, BinomialError> {
         if p.is_nan() || !(0.0..=1.0).contains(&p) {
-            Err(StatsError::BadParams)
+            Err(BinomialError::ProbabilityInvalid)
         } else {
             Ok(Binomial { p, n })
         }
@@ -332,7 +349,7 @@ mod tests {
     use crate::distribution::internal::*;
     use crate::testing_boiler;
 
-    testing_boiler!(p: f64, n: u64; Binomial; StatsError);
+    testing_boiler!(p: f64, n: u64; Binomial; BinomialError);
 
     #[test]
     fn test_create() {

--- a/src/distribution/binomial.rs
+++ b/src/distribution/binomial.rs
@@ -328,12 +328,11 @@ impl Discrete<u64, f64> for Binomial {
 #[rustfmt::skip]
 #[cfg(test)]
 mod tests {
-    use crate::statistics::*;
-    use crate::distribution::{DiscreteCDF, Discrete, Binomial};
+    use super::*;
     use crate::distribution::internal::*;
     use crate::testing_boiler;
 
-    testing_boiler!(p: f64, n: u64; Binomial);
+    testing_boiler!(p: f64, n: u64; Binomial; StatsError);
 
     #[test]
     fn test_create() {

--- a/src/distribution/binomial.rs
+++ b/src/distribution/binomial.rs
@@ -34,6 +34,7 @@ pub enum BinomialError {
 }
 
 impl std::fmt::Display for BinomialError {
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             BinomialError::ProbabilityInvalid => write!(f, "Probability is NaN or not in [0, 1]"),

--- a/src/distribution/categorical.rs
+++ b/src/distribution/categorical.rs
@@ -351,12 +351,11 @@ fn test_binary_index() {
 #[rustfmt::skip]
 #[cfg(test)]
 mod tests {
-    use crate::statistics::*;
-    use crate::distribution::{Categorical, Discrete, DiscreteCDF};
+    use super::*;
     use crate::distribution::internal::*;
     use crate::testing_boiler;
 
-    testing_boiler!(prob_mass: &[f64]; Categorical);
+    testing_boiler!(prob_mass: &[f64]; Categorical; StatsError);
 
     #[test]
     fn test_create() {

--- a/src/distribution/categorical.rs
+++ b/src/distribution/categorical.rs
@@ -41,6 +41,7 @@ pub enum CategoricalError {
 }
 
 impl std::fmt::Display for CategoricalError {
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             CategoricalError::ProbMassEmpty => write!(f, "Probability mass is empty"),

--- a/src/distribution/cauchy.rs
+++ b/src/distribution/cauchy.rs
@@ -252,11 +252,11 @@ impl Continuous<f64, f64> for Cauchy {
 #[rustfmt::skip]
 #[cfg(test)]
 mod tests {
-    use crate::{statistics::*, testing_boiler};
-    use crate::distribution::{ContinuousCDF, Continuous, Cauchy};
+    use super::*;
     use crate::distribution::internal::*;
+    use crate::testing_boiler;
 
-    testing_boiler!(location: f64, scale: f64; Cauchy);
+    testing_boiler!(location: f64, scale: f64; Cauchy; StatsError);
 
     #[test]
     fn test_create() {

--- a/src/distribution/cauchy.rs
+++ b/src/distribution/cauchy.rs
@@ -34,6 +34,7 @@ pub enum CauchyError {
 }
 
 impl std::fmt::Display for CauchyError {
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             CauchyError::LocationInvalid => write!(f, "Location is NaN"),

--- a/src/distribution/chi.rs
+++ b/src/distribution/chi.rs
@@ -1,7 +1,6 @@
 use crate::distribution::{Continuous, ContinuousCDF};
 use crate::function::gamma;
 use crate::statistics::*;
-use crate::{Result, StatsError};
 use rand::Rng;
 use std::f64;
 
@@ -24,6 +23,26 @@ pub struct Chi {
     freedom: f64,
 }
 
+/// Represents the errors that can occur when creating a [`Chi`].
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
+#[non_exhaustive]
+pub enum ChiError {
+    /// The degrees of freedom are NaN, zero or less than zero.
+    FreedomInvalid,
+}
+
+impl std::fmt::Display for ChiError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            ChiError::FreedomInvalid => {
+                write!(f, "Degrees of freedom are NaN, zero or less than zero")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ChiError {}
+
 impl Chi {
     /// Constructs a new chi distribution
     /// with `freedom` degrees of freedom
@@ -44,9 +63,9 @@ impl Chi {
     /// result = Chi::new(0.0);
     /// assert!(result.is_err());
     /// ```
-    pub fn new(freedom: f64) -> Result<Chi> {
+    pub fn new(freedom: f64) -> Result<Chi, ChiError> {
         if freedom.is_nan() || freedom <= 0.0 {
-            Err(StatsError::BadParams)
+            Err(ChiError::FreedomInvalid)
         } else {
             Ok(Chi { freedom })
         }
@@ -329,7 +348,7 @@ mod tests {
     use crate::distribution::internal::*;
     use crate::testing_boiler;
 
-    testing_boiler!(freedom: f64; Chi; StatsError);
+    testing_boiler!(freedom: f64; Chi; ChiError);
 
     #[test]
     fn test_create() {

--- a/src/distribution/chi.rs
+++ b/src/distribution/chi.rs
@@ -325,13 +325,11 @@ impl Continuous<f64, f64> for Chi {
 #[rustfmt::skip]
 #[cfg(test)]
 mod tests {
-    use std::f64;
+    use super::*;
     use crate::distribution::internal::*;
-    use crate::distribution::{Chi, Continuous, ContinuousCDF};
-    use crate::statistics::*;
     use crate::testing_boiler;
 
-    testing_boiler!(freedom: f64; Chi);
+    testing_boiler!(freedom: f64; Chi; StatsError);
 
     #[test]
     fn test_create() {

--- a/src/distribution/chi.rs
+++ b/src/distribution/chi.rs
@@ -32,6 +32,7 @@ pub enum ChiError {
 }
 
 impl std::fmt::Display for ChiError {
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             ChiError::FreedomInvalid => {

--- a/src/distribution/chi_squared.rs
+++ b/src/distribution/chi_squared.rs
@@ -1,6 +1,5 @@
-use crate::distribution::{Continuous, ContinuousCDF, Gamma};
+use crate::distribution::{Continuous, ContinuousCDF, Gamma, GammaError};
 use crate::statistics::*;
-use crate::Result;
 use rand::Rng;
 use std::f64;
 
@@ -48,7 +47,7 @@ impl ChiSquared {
     /// result = ChiSquared::new(0.0);
     /// assert!(result.is_err());
     /// ```
-    pub fn new(freedom: f64) -> Result<ChiSquared> {
+    pub fn new(freedom: f64) -> Result<ChiSquared, GammaError> {
         Gamma::new(freedom / 2.0, 0.5).map(|g| ChiSquared { freedom, g })
     }
 
@@ -308,10 +307,9 @@ impl Continuous<f64, f64> for ChiSquared {
 mod tests {
     use super::*;
     use crate::distribution::internal::*;
-    use crate::StatsError;
     use crate::testing_boiler;
 
-    testing_boiler!(freedom: f64; ChiSquared; StatsError);
+    testing_boiler!(freedom: f64; ChiSquared; GammaError);
 
     #[test]
     fn test_median() {

--- a/src/distribution/chi_squared.rs
+++ b/src/distribution/chi_squared.rs
@@ -306,12 +306,12 @@ impl Continuous<f64, f64> for ChiSquared {
 #[rustfmt::skip]
 #[cfg(test)]
 mod tests {
-    use crate::statistics::Median;
-    use crate::distribution::ChiSquared;
+    use super::*;
     use crate::distribution::internal::*;
+    use crate::StatsError;
     use crate::testing_boiler;
 
-    testing_boiler!(freedom: f64; ChiSquared);
+    testing_boiler!(freedom: f64; ChiSquared; StatsError);
 
     #[test]
     fn test_median() {

--- a/src/distribution/dirac.rs
+++ b/src/distribution/dirac.rs
@@ -1,6 +1,5 @@
 use crate::distribution::ContinuousCDF;
 use crate::statistics::*;
-use crate::{Result, StatsError};
 use rand::Rng;
 
 /// Implements the [Dirac Delta](https://en.wikipedia.org/wiki/Dirac_delta_function#As_a_distribution)
@@ -18,8 +17,26 @@ use rand::Rng;
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct Dirac(f64);
 
+/// Represents the errors that can occur when creating a [`Dirac`].
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
+#[non_exhaustive]
+pub enum DiracError {
+    /// The value v is NaN.
+    ValueInvalid,
+}
+
+impl std::fmt::Display for DiracError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            DiracError::ValueInvalid => write!(f, "Value v is NaN"),
+        }
+    }
+}
+
+impl std::error::Error for DiracError {}
+
 impl Dirac {
-    ///  Constructs a new dirac distribution function at value `v`.
+    /// Constructs a new dirac distribution function at value `v`.
     ///
     /// # Errors
     ///
@@ -36,9 +53,9 @@ impl Dirac {
     /// result = Dirac::new(f64::NAN);
     /// assert!(result.is_err());
     /// ```
-    pub fn new(v: f64) -> Result<Self> {
+    pub fn new(v: f64) -> Result<Self, DiracError> {
         if v.is_nan() {
-            Err(StatsError::BadParams)
+            Err(DiracError::ValueInvalid)
         } else {
             Ok(Dirac(v))
         }
@@ -196,7 +213,7 @@ mod tests {
     use super::*;
     use crate::testing_boiler;
 
-    testing_boiler!(v: f64; Dirac; StatsError);
+    testing_boiler!(v: f64; Dirac; DiracError);
 
     #[test]
     fn test_create() {

--- a/src/distribution/dirac.rs
+++ b/src/distribution/dirac.rs
@@ -26,6 +26,7 @@ pub enum DiracError {
 }
 
 impl std::fmt::Display for DiracError {
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             DiracError::ValueInvalid => write!(f, "Value v is NaN"),

--- a/src/distribution/dirac.rs
+++ b/src/distribution/dirac.rs
@@ -193,11 +193,10 @@ impl Mode<Option<f64>> for Dirac {
 #[rustfmt::skip]
 #[cfg(test)]
 mod tests {
-    use crate::distribution::{ContinuousCDF, Dirac};
-    use crate::statistics::*;
+    use super::*;
     use crate::testing_boiler;
 
-    testing_boiler!(v: f64; Dirac);
+    testing_boiler!(v: f64; Dirac; StatsError);
 
     #[test]
     fn test_create() {

--- a/src/distribution/dirichlet.rs
+++ b/src/distribution/dirichlet.rs
@@ -369,14 +369,11 @@ where
 #[rustfmt::skip]
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     use std::fmt::{Debug, Display};
 
     use nalgebra::{dmatrix, dvector, vector, DimMin, OVector};
-
-    use crate::{
-        distribution::{Continuous, Dirichlet},
-        statistics::{MeanN, VarianceN},
-    };
 
     fn try_create<D>(alpha: OVector<f64, D>) -> Dirichlet<D>
     where
@@ -579,5 +576,11 @@ mod tests {
     fn test_ln_pdf_bad_input_sum() {
         let n = try_create(vector![0.1, 0.3, 0.5, 0.8]);
         n.ln_pdf(&vector![0.5, 0.25, 0.8, 0.9]);
+    }
+
+    #[test]
+    fn test_error_is_sync_send() {
+        fn assert_sync_send<T: Sync + Send>() {}
+        assert_sync_send::<DirichletError>();
     }
 }

--- a/src/distribution/dirichlet.rs
+++ b/src/distribution/dirichlet.rs
@@ -43,6 +43,7 @@ pub enum DirichletError {
 }
 
 impl std::fmt::Display for DirichletError {
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             DirichletError::AlphaTooShort => write!(f, "Alpha contains less than two elements"),

--- a/src/distribution/discrete_uniform.rs
+++ b/src/distribution/discrete_uniform.rs
@@ -1,6 +1,5 @@
 use crate::distribution::{Discrete, DiscreteCDF};
 use crate::statistics::*;
-use crate::{Result, StatsError};
 use rand::Rng;
 
 /// Implements the [Discrete
@@ -23,6 +22,24 @@ pub struct DiscreteUniform {
     max: i64,
 }
 
+/// Represents the errors that can occur when creating a [`DiscreteUniform`].
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
+#[non_exhaustive]
+pub enum DiscreteUniformError {
+    /// The maximum is less than the minimum.
+    MinMaxInvalid,
+}
+
+impl std::fmt::Display for DiscreteUniformError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            DiscreteUniformError::MinMaxInvalid => write!(f, "Maximum is less than minimum"),
+        }
+    }
+}
+
+impl std::error::Error for DiscreteUniformError {}
+
 impl DiscreteUniform {
     /// Constructs a new discrete uniform distribution with a minimum value
     /// of `min` and a maximum value of `max`.
@@ -42,9 +59,9 @@ impl DiscreteUniform {
     /// result = DiscreteUniform::new(5, 0);
     /// assert!(result.is_err());
     /// ```
-    pub fn new(min: i64, max: i64) -> Result<DiscreteUniform> {
+    pub fn new(min: i64, max: i64) -> Result<DiscreteUniform, DiscreteUniformError> {
         if max < min {
-            Err(StatsError::BadParams)
+            Err(DiscreteUniformError::MinMaxInvalid)
         } else {
             Ok(DiscreteUniform { min, max })
         }
@@ -259,7 +276,7 @@ mod tests {
     use super::*;
     use crate::testing_boiler;
 
-    testing_boiler!(min: i64, max: i64; DiscreteUniform; StatsError);
+    testing_boiler!(min: i64, max: i64; DiscreteUniform; DiscreteUniformError);
 
     #[test]
     fn test_create() {

--- a/src/distribution/discrete_uniform.rs
+++ b/src/distribution/discrete_uniform.rs
@@ -256,11 +256,10 @@ impl Discrete<i64, f64> for DiscreteUniform {
 #[rustfmt::skip]
 #[cfg(test)]
 mod tests {
-    use crate::distribution::{DiscreteCDF, Discrete, DiscreteUniform};
-    use crate::statistics::*;
+    use super::*;
     use crate::testing_boiler;
 
-    testing_boiler!(min: i64, max: i64; DiscreteUniform);
+    testing_boiler!(min: i64, max: i64; DiscreteUniform; StatsError);
 
     #[test]
     fn test_create() {

--- a/src/distribution/discrete_uniform.rs
+++ b/src/distribution/discrete_uniform.rs
@@ -31,6 +31,7 @@ pub enum DiscreteUniformError {
 }
 
 impl std::fmt::Display for DiscreteUniformError {
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             DiscreteUniformError::MinMaxInvalid => write!(f, "Maximum is less than minimum"),

--- a/src/distribution/empirical.rs
+++ b/src/distribution/empirical.rs
@@ -1,6 +1,5 @@
 use crate::distribution::{ContinuousCDF, Uniform};
 use crate::statistics::*;
-use crate::Result;
 use core::cmp::Ordering;
 use rand::Rng;
 use std::collections::BTreeMap;
@@ -48,6 +47,8 @@ impl Empirical {
     /// Constructs a new discrete uniform distribution with a minimum value
     /// of `min` and a maximum value of `max`.
     ///
+    /// Note that this will always succeed and never return the [`Err`][Result::Err] variant.
+    ///
     /// # Examples
     ///
     /// ```
@@ -56,7 +57,8 @@ impl Empirical {
     /// let mut result = Empirical::new();
     /// assert!(result.is_ok());
     /// ```
-    pub fn new() -> Result<Empirical> {
+    #[allow(clippy::result_unit_err)]
+    pub fn new() -> Result<Empirical, ()> {
         Ok(Empirical {
             sum: 0.,
             mean_and_var: None,

--- a/src/distribution/erlang.rs
+++ b/src/distribution/erlang.rs
@@ -293,11 +293,12 @@ impl Continuous<f64, f64> for Erlang {
 #[rustfmt::skip]
 #[cfg(test)]
 mod tests {
-    use crate::distribution::Erlang;
+    use super::*;
     use crate::distribution::internal::*;
+    use crate::StatsError;
     use crate::testing_boiler;
 
-    testing_boiler!(shape: u64, rate: f64; Erlang);
+    testing_boiler!(shape: u64, rate: f64; Erlang; StatsError);
 
     #[test]
     fn test_create() {

--- a/src/distribution/exponential.rs
+++ b/src/distribution/exponential.rs
@@ -33,6 +33,7 @@ pub enum ExpError {
 }
 
 impl std::fmt::Display for ExpError {
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             ExpError::RateInvalid => write!(f, "Rate is NaN, zero or less than zero"),

--- a/src/distribution/exponential.rs
+++ b/src/distribution/exponential.rs
@@ -1,6 +1,5 @@
 use crate::distribution::{ziggurat, Continuous, ContinuousCDF};
 use crate::statistics::*;
-use crate::{Result, StatsError};
 use rand::Rng;
 use std::f64;
 
@@ -25,13 +24,31 @@ pub struct Exp {
     rate: f64,
 }
 
+/// Represents the errors that can occur when creating a [`Exp`].
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
+#[non_exhaustive]
+pub enum ExpError {
+    /// The rate is NaN, zero or less than zero.
+    RateInvalid,
+}
+
+impl std::fmt::Display for ExpError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            ExpError::RateInvalid => write!(f, "Rate is NaN, zero or less than zero"),
+        }
+    }
+}
+
+impl std::error::Error for ExpError {}
+
 impl Exp {
     /// Constructs a new exponential distribution with a
     /// rate (λ) of `rate`.
     ///
     /// # Errors
     ///
-    /// Returns an error if rate is `NaN` or `rate <= 0.0`
+    /// Returns an error if rate is `NaN` or `rate <= 0.0`.
     ///
     /// # Examples
     ///
@@ -44,9 +61,9 @@ impl Exp {
     /// result = Exp::new(-1.0);
     /// assert!(result.is_err());
     /// ```
-    pub fn new(rate: f64) -> Result<Exp> {
+    pub fn new(rate: f64) -> Result<Exp, ExpError> {
         if rate.is_nan() || rate <= 0.0 {
-            Err(StatsError::BadParams)
+            Err(ExpError::RateInvalid)
         } else {
             Ok(Exp { rate })
         }
@@ -283,7 +300,7 @@ mod tests {
     use crate::distribution::internal::*;
     use crate::testing_boiler;
 
-    testing_boiler!(rate: f64; Exp; StatsError);
+    testing_boiler!(rate: f64; Exp; ExpError);
 
     #[test]
     fn test_create() {

--- a/src/distribution/exponential.rs
+++ b/src/distribution/exponential.rs
@@ -279,13 +279,11 @@ impl Continuous<f64, f64> for Exp {
 #[rustfmt::skip]
 #[cfg(test)]
 mod tests {
-    use std::f64;
-    use crate::distribution::{ContinuousCDF, Continuous, Exp};
+    use super::*;
     use crate::distribution::internal::*;
-    use crate::statistics::*;
     use crate::testing_boiler;
 
-    testing_boiler!(rate: f64; Exp);
+    testing_boiler!(rate: f64; Exp; StatsError);
 
     #[test]
     fn test_create() {

--- a/src/distribution/fisher_snedecor.rs
+++ b/src/distribution/fisher_snedecor.rs
@@ -37,6 +37,7 @@ pub enum FisherSnedecorError {
 }
 
 impl std::fmt::Display for FisherSnedecorError {
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             FisherSnedecorError::Freedom1Invalid => {

--- a/src/distribution/fisher_snedecor.rs
+++ b/src/distribution/fisher_snedecor.rs
@@ -385,12 +385,11 @@ impl Continuous<f64, f64> for FisherSnedecor {
 #[rustfmt::skip]
 #[cfg(test)]
 mod tests {
-    use crate::distribution::{ContinuousCDF, Continuous, FisherSnedecor};
+    use super::*;
     use crate::distribution::internal::*;
-    use crate::statistics::*;
     use crate::testing_boiler;
 
-    testing_boiler!(freedom_1: f64, freedom_2: f64; FisherSnedecor);
+    testing_boiler!(freedom_1: f64, freedom_2: f64; FisherSnedecor; StatsError);
 
     #[test]
     fn test_create() {

--- a/src/distribution/gamma.rs
+++ b/src/distribution/gamma.rs
@@ -406,7 +406,7 @@ mod tests {
     use crate::distribution::internal::*;
     use crate::testing_boiler;
 
-    testing_boiler!(shape: f64, rate: f64; Gamma);
+    testing_boiler!(shape: f64, rate: f64; Gamma; StatsError);
 
     #[test]
     fn test_create() {

--- a/src/distribution/gamma.rs
+++ b/src/distribution/gamma.rs
@@ -39,6 +39,7 @@ pub enum GammaError {
 }
 
 impl std::fmt::Display for GammaError {
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             GammaError::ShapeInvalid => write!(f, "Shape is NaN zero, or less than zero."),

--- a/src/distribution/geometric.rs
+++ b/src/distribution/geometric.rs
@@ -1,6 +1,5 @@
 use crate::distribution::{Discrete, DiscreteCDF};
 use crate::statistics::*;
-use crate::{Result, StatsError};
 use rand::distributions::OpenClosed01;
 use rand::Rng;
 use std::f64;
@@ -25,6 +24,24 @@ pub struct Geometric {
     p: f64,
 }
 
+/// Represents the errors that can occur when creating a [`Geometric`].
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
+#[non_exhaustive]
+pub enum GeometricError {
+    /// The probability is NaN or not in `(0, 1]`.
+    ProbabilityInvalid,
+}
+
+impl std::fmt::Display for GeometricError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            GeometricError::ProbabilityInvalid => write!(f, "Probability is NaN or not in (0, 1]"),
+        }
+    }
+}
+
+impl std::error::Error for GeometricError {}
+
 impl Geometric {
     /// Constructs a new shifted geometric distribution with a probability
     /// of `p`
@@ -44,9 +61,9 @@ impl Geometric {
     /// result = Geometric::new(0.0);
     /// assert!(result.is_err());
     /// ```
-    pub fn new(p: f64) -> Result<Geometric> {
+    pub fn new(p: f64) -> Result<Geometric, GeometricError> {
         if p <= 0.0 || p > 1.0 || p.is_nan() {
-            Err(StatsError::BadParams)
+            Err(GeometricError::ProbabilityInvalid)
         } else {
             Ok(Geometric { p })
         }
@@ -277,7 +294,7 @@ mod tests {
     use crate::distribution::internal::*;
     use crate::testing_boiler;
 
-    testing_boiler!(p: f64; Geometric; StatsError);
+    testing_boiler!(p: f64; Geometric; GeometricError);
 
     #[test]
     fn test_create() {

--- a/src/distribution/geometric.rs
+++ b/src/distribution/geometric.rs
@@ -33,6 +33,7 @@ pub enum GeometricError {
 }
 
 impl std::fmt::Display for GeometricError {
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             GeometricError::ProbabilityInvalid => write!(f, "Probability is NaN or not in (0, 1]"),

--- a/src/distribution/geometric.rs
+++ b/src/distribution/geometric.rs
@@ -273,12 +273,11 @@ impl Discrete<u64, f64> for Geometric {
 #[rustfmt::skip]
 #[cfg(test)]
 mod tests {
-    use crate::distribution::{DiscreteCDF, Discrete, Geometric};
+    use super::*;
     use crate::distribution::internal::*;
-    use crate::statistics::*;
     use crate::testing_boiler;
 
-    testing_boiler!(p: f64; Geometric);
+    testing_boiler!(p: f64; Geometric; StatsError);
 
     #[test]
     fn test_create() {

--- a/src/distribution/hypergeometric.rs
+++ b/src/distribution/hypergeometric.rs
@@ -372,12 +372,11 @@ impl Discrete<u64, f64> for Hypergeometric {
 #[rustfmt::skip]
 #[cfg(test)]
 mod tests {
-    use crate::distribution::{DiscreteCDF, Discrete, Hypergeometric};
+    use super::*;
     use crate::distribution::internal::*;
-    use crate::statistics::*;
     use crate::testing_boiler;
 
-    testing_boiler!(population: u64, successes: u64, draws: u64; Hypergeometric);
+    testing_boiler!(population: u64, successes: u64, draws: u64; Hypergeometric; StatsError);
 
     #[test]
     fn test_create() {

--- a/src/distribution/hypergeometric.rs
+++ b/src/distribution/hypergeometric.rs
@@ -28,6 +28,7 @@ pub enum HypergeometricError {
 }
 
 impl std::fmt::Display for HypergeometricError {
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             HypergeometricError::TooManySuccesses => write!(f, "successes > population"),

--- a/src/distribution/internal.rs
+++ b/src/distribution/internal.rs
@@ -100,7 +100,7 @@ pub mod test {
 
     #[macro_export]
     macro_rules! testing_boiler {
-        ($($arg_name:ident: $arg_ty:ty),+; $dist:ty) => {
+        ($($arg_name:ident: $arg_ty:ty),+; $dist:ty; $dist_err:ty) => {
             fn make_param_text($($arg_name: $arg_ty),+) -> String {
                 // ""
                 let mut param_text = String::new();
@@ -140,7 +140,7 @@ pub mod test {
             /// Returns the error when creating a distribution with the given parameters,
             /// panicking if `::new` succeeds.
             #[allow(dead_code)]
-            fn create_err($($arg_name: $arg_ty),+) -> $crate::StatsError {
+            fn create_err($($arg_name: $arg_ty),+) -> $dist_err {
                 match <$dist>::new($($arg_name),+) {
                     Err(e) => e,
                     Ok(d) => panic!(
@@ -281,7 +281,7 @@ pub mod test {
         use crate::statistics::*;
         use crate::StatsError;
 
-        testing_boiler!(p: f64, n: u64; Binomial);
+        testing_boiler!(p: f64, n: u64; Binomial; StatsError);
 
         #[test]
         fn create_ok_success() {

--- a/src/distribution/internal.rs
+++ b/src/distribution/internal.rs
@@ -241,6 +241,13 @@ pub mod test {
                     )
                 }
             }
+
+            /// Asserts that associated error type is Send and Sync
+            #[test]
+            fn test_error_is_sync_send() {
+                fn assert_sync_send<T: Sync + Send>() {}
+                assert_sync_send::<$dist_err>();
+            }
         };
     }
 

--- a/src/distribution/inverse_gamma.rs
+++ b/src/distribution/inverse_gamma.rs
@@ -313,12 +313,11 @@ impl Continuous<f64, f64> for InverseGamma {
 #[rustfmt::skip]
 #[cfg(test)]
 mod tests {
-    use crate::distribution::{ContinuousCDF, Continuous, InverseGamma};
+    use super::*;
     use crate::distribution::internal::*;
-    use crate::statistics::*;
     use crate::testing_boiler;
 
-    testing_boiler!(shape: f64, rate: f64; InverseGamma);
+    testing_boiler!(shape: f64, rate: f64; InverseGamma; StatsError);
 
     #[test]
     fn test_create() {

--- a/src/distribution/inverse_gamma.rs
+++ b/src/distribution/inverse_gamma.rs
@@ -37,6 +37,7 @@ pub enum InverseGammaError {
 }
 
 impl std::fmt::Display for InverseGammaError {
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             InverseGammaError::ShapeInvalid => {

--- a/src/distribution/laplace.rs
+++ b/src/distribution/laplace.rs
@@ -34,6 +34,7 @@ pub enum LaplaceError {
 }
 
 impl std::fmt::Display for LaplaceError {
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             LaplaceError::LocationInvalid => write!(f, "Location is NaN"),

--- a/src/distribution/laplace.rs
+++ b/src/distribution/laplace.rs
@@ -304,7 +304,7 @@ mod tests {
 
     use crate::testing_boiler;
 
-    testing_boiler!(location: f64, scale: f64; Laplace);
+    testing_boiler!(location: f64, scale: f64; Laplace; StatsError);
 
     // A wrapper for the `assert_relative_eq!` macro from the approx crate.
     //

--- a/src/distribution/log_normal.rs
+++ b/src/distribution/log_normal.rs
@@ -305,12 +305,11 @@ impl Continuous<f64, f64> for LogNormal {
 #[rustfmt::skip]
 #[cfg(test)]
 mod tests {
-    use crate::distribution::{ContinuousCDF, Continuous, LogNormal};
+    use super::*;
     use crate::distribution::internal::*;
-    use crate::statistics::*;
     use crate::testing_boiler;
 
-    testing_boiler!(mean: f64, std_dev: f64; LogNormal);
+    testing_boiler!(mean: f64, std_dev: f64; LogNormal; StatsError);
 
     #[test]
     fn test_create() {

--- a/src/distribution/log_normal.rs
+++ b/src/distribution/log_normal.rs
@@ -38,6 +38,7 @@ pub enum LogNormalError {
 }
 
 impl std::fmt::Display for LogNormalError {
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             LogNormalError::LocationInvalid => write!(f, "Location is NaN"),

--- a/src/distribution/mod.rs
+++ b/src/distribution/mod.rs
@@ -6,40 +6,40 @@ use ::num_traits::{Float, Num};
 use num_traits::NumAssignOps;
 
 pub use self::bernoulli::Bernoulli;
-pub use self::beta::Beta;
-pub use self::binomial::Binomial;
-pub use self::categorical::Categorical;
-pub use self::cauchy::Cauchy;
-pub use self::chi::Chi;
+pub use self::beta::{Beta, BetaError};
+pub use self::binomial::{Binomial, BinomialError};
+pub use self::categorical::{Categorical, CategoricalError};
+pub use self::cauchy::{Cauchy, CauchyError};
+pub use self::chi::{Chi, ChiError};
 pub use self::chi_squared::ChiSquared;
-pub use self::dirac::Dirac;
+pub use self::dirac::{Dirac, DiracError};
 #[cfg(feature = "nalgebra")]
-pub use self::dirichlet::Dirichlet;
-pub use self::discrete_uniform::DiscreteUniform;
+pub use self::dirichlet::{Dirichlet, DirichletError};
+pub use self::discrete_uniform::{DiscreteUniform, DiscreteUniformError};
 pub use self::empirical::Empirical;
 pub use self::erlang::Erlang;
-pub use self::exponential::Exp;
-pub use self::fisher_snedecor::FisherSnedecor;
-pub use self::gamma::Gamma;
-pub use self::geometric::Geometric;
-pub use self::hypergeometric::Hypergeometric;
-pub use self::inverse_gamma::InverseGamma;
-pub use self::laplace::Laplace;
-pub use self::log_normal::LogNormal;
+pub use self::exponential::{Exp, ExpError};
+pub use self::fisher_snedecor::{FisherSnedecor, FisherSnedecorError};
+pub use self::gamma::{Gamma, GammaError};
+pub use self::geometric::{Geometric, GeometricError};
+pub use self::hypergeometric::{Hypergeometric, HypergeometricError};
+pub use self::inverse_gamma::{InverseGamma, InverseGammaError};
+pub use self::laplace::{Laplace, LaplaceError};
+pub use self::log_normal::{LogNormal, LogNormalError};
 #[cfg(feature = "nalgebra")]
-pub use self::multinomial::Multinomial;
+pub use self::multinomial::{Multinomial, MultinomialError};
 #[cfg(feature = "nalgebra")]
-pub use self::multivariate_normal::MultivariateNormal;
+pub use self::multivariate_normal::{MultivariateNormal, MultivariateNormalError};
 #[cfg(feature = "nalgebra")]
-pub use self::multivariate_students_t::MultivariateStudent;
-pub use self::negative_binomial::NegativeBinomial;
-pub use self::normal::Normal;
-pub use self::pareto::Pareto;
-pub use self::poisson::Poisson;
-pub use self::students_t::StudentsT;
-pub use self::triangular::Triangular;
-pub use self::uniform::Uniform;
-pub use self::weibull::Weibull;
+pub use self::multivariate_students_t::{MultivariateStudent, MultivariateStudentError};
+pub use self::negative_binomial::{NegativeBinomial, NegativeBinomialError};
+pub use self::normal::{Normal, NormalError};
+pub use self::pareto::{Pareto, ParetoError};
+pub use self::poisson::{Poisson, PoissonError};
+pub use self::students_t::{StudentsT, StudentsTError};
+pub use self::triangular::{Triangular, TriangularError};
+pub use self::uniform::{Uniform, UniformError};
+pub use self::weibull::{Weibull, WeibullError};
 
 mod bernoulli;
 mod beta;

--- a/src/distribution/multinomial.rs
+++ b/src/distribution/multinomial.rs
@@ -500,6 +500,12 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_error_is_sync_send() {
+        fn assert_sync_send<T: Sync + Send>() {}
+        assert_sync_send::<MultinomialError>();
+    }
+
     //     #[test]
     //     #[should_panic]
     //     fn test_pmf_x_wrong_length() {

--- a/src/distribution/multinomial.rs
+++ b/src/distribution/multinomial.rs
@@ -47,6 +47,7 @@ pub enum MultinomialError {
 }
 
 impl std::fmt::Display for MultinomialError {
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             MultinomialError::NotEnoughProbabilities => write!(f, "Fewer than two probabilities"),

--- a/src/distribution/multivariate_normal.rs
+++ b/src/distribution/multivariate_normal.rs
@@ -127,6 +127,7 @@ pub enum MultivariateNormalError {
 }
 
 impl std::fmt::Display for MultivariateNormalError {
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             MultivariateNormalError::CovInvalid => {

--- a/src/distribution/multivariate_normal.rs
+++ b/src/distribution/multivariate_normal.rs
@@ -389,6 +389,8 @@ mod tests  {
         statistics::{Max, MeanN, Min, Mode, VarianceN},
     };
 
+    use super::MultivariateNormalError;
+
     fn try_create<D>(mean: OVector<f64, D>, covariance: OMatrix<f64, D, D>) -> MultivariateNormal<D>
     where
         D: DimMin<D, Output = D>,
@@ -702,5 +704,11 @@ mod tests  {
     fn test_pdf_mismatched_arg_size() {
         let mvn = MultivariateNormal::new(vec![0., 0.], vec![1., 0., 0., 1.,]).unwrap();
         mvn.pdf(&vec![1.].into()); // x.size != mu.size
+    }
+
+    #[test]
+    fn test_error_is_sync_send() {
+        fn assert_sync_send<T: Sync + Send>() {}
+        assert_sync_send::<MultivariateNormalError>();
     }
 }

--- a/src/distribution/multivariate_students_t.rs
+++ b/src/distribution/multivariate_students_t.rs
@@ -397,6 +397,8 @@ mod tests  {
         statistics::{Max, MeanN, Min, Mode, VarianceN},
     };
 
+    use super::MultivariateStudentError;
+
     fn try_create(location: Vec<f64>, scale: Vec<f64>, freedom: f64) -> MultivariateStudent<Dyn>
     {
         let mvs = MultivariateStudent::new(location, scale, freedom);
@@ -614,5 +616,9 @@ mod tests  {
         assert_eq!(mvs.scale_chol_decomp(), &OMatrix::<f64, Dyn, Dyn>::identity(2, 2));
     }
         
-    
+    #[test]
+    fn test_error_is_sync_send() {
+        fn assert_sync_send<T: Sync + Send>() {}
+        assert_sync_send::<MultivariateStudentError>();
+    }
 }

--- a/src/distribution/multivariate_students_t.rs
+++ b/src/distribution/multivariate_students_t.rs
@@ -61,6 +61,7 @@ pub enum MultivariateStudentError {
 }
 
 impl std::fmt::Display for MultivariateStudentError {
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             MultivariateStudentError::ScaleInvalid => {

--- a/src/distribution/negative_binomial.rs
+++ b/src/distribution/negative_binomial.rs
@@ -291,12 +291,11 @@ impl Discrete<u64, f64> for NegativeBinomial {
 #[rustfmt::skip]
 #[cfg(test)]
 mod tests {
-    use crate::distribution::{DiscreteCDF, Discrete, NegativeBinomial};
+    use super::*;
     use crate::distribution::internal::test;
-    use crate::statistics::*;
     use crate::testing_boiler;
 
-    testing_boiler!(r: f64, p: f64; NegativeBinomial);
+    testing_boiler!(r: f64, p: f64; NegativeBinomial; StatsError);
 
     #[test]
     fn test_create() {

--- a/src/distribution/negative_binomial.rs
+++ b/src/distribution/negative_binomial.rs
@@ -52,6 +52,7 @@ pub enum NegativeBinomialError {
 }
 
 impl std::fmt::Display for NegativeBinomialError {
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             NegativeBinomialError::RInvalid => write!(f, "r is NaN or less than zero"),

--- a/src/distribution/normal.rs
+++ b/src/distribution/normal.rs
@@ -36,6 +36,7 @@ pub enum NormalError {
 }
 
 impl std::fmt::Display for NormalError {
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             NormalError::MeanInvalid => write!(f, "Mean is NaN"),

--- a/src/distribution/normal.rs
+++ b/src/distribution/normal.rs
@@ -334,12 +334,11 @@ impl std::default::Default for Normal {
 #[rustfmt::skip]
 #[cfg(test)]
 mod tests {
-    use crate::distribution::{ContinuousCDF, Continuous, Normal};
+    use super::*;
     use crate::distribution::internal::*;
-    use crate::statistics::*;
     use crate::testing_boiler;
 
-    testing_boiler!(mean: f64, std_dev: f64; Normal);
+    testing_boiler!(mean: f64, std_dev: f64; Normal; StatsError);
 
     #[test]
     fn test_create() {

--- a/src/distribution/pareto.rs
+++ b/src/distribution/pareto.rs
@@ -354,12 +354,11 @@ impl Continuous<f64, f64> for Pareto {
 #[rustfmt::skip]
 #[cfg(test)]
 mod tests {
-    use crate::distribution::{ContinuousCDF, Continuous, Pareto};
+    use super::*;
     use crate::distribution::internal::*;
-    use crate::statistics::*;
     use crate::testing_boiler;
 
-    testing_boiler!(scale: f64, shape: f64; Pareto);
+    testing_boiler!(scale: f64, shape: f64; Pareto; StatsError);
 
     #[test]
     fn test_create() {

--- a/src/distribution/pareto.rs
+++ b/src/distribution/pareto.rs
@@ -36,6 +36,7 @@ pub enum ParetoError {
 }
 
 impl std::fmt::Display for ParetoError {
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             ParetoError::ScaleInvalid => write!(f, "Scale is NaN, zero, or less than zero"),

--- a/src/distribution/poisson.rs
+++ b/src/distribution/poisson.rs
@@ -304,12 +304,11 @@ pub fn sample_unchecked<R: Rng + ?Sized>(rng: &mut R, lambda: f64) -> f64 {
 #[rustfmt::skip]
 #[cfg(test)]
 mod tests {
-    use crate::distribution::{DiscreteCDF, Discrete, Poisson};
+    use super::*;
     use crate::distribution::internal::*;
-    use crate::statistics::*;
     use crate::testing_boiler;
 
-    testing_boiler!(lambda: f64; Poisson);
+    testing_boiler!(lambda: f64; Poisson; StatsError);
 
     #[test]
     fn test_create() {

--- a/src/distribution/poisson.rs
+++ b/src/distribution/poisson.rs
@@ -1,7 +1,6 @@
 use crate::distribution::{Discrete, DiscreteCDF};
 use crate::function::{factorial, gamma};
 use crate::statistics::*;
-use crate::{Result, StatsError};
 use rand::Rng;
 use std::f64;
 
@@ -24,6 +23,24 @@ pub struct Poisson {
     lambda: f64,
 }
 
+/// Represents the errors that can occur when creating a [`Poisson`].
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
+#[non_exhaustive]
+pub enum PoissonError {
+    /// The lambda is NaN, zero or less than zero.
+    LambdaInvalid,
+}
+
+impl std::fmt::Display for PoissonError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            PoissonError::LambdaInvalid => write!(f, "Lambda is NaN, zero or less than zero"),
+        }
+    }
+}
+
+impl std::error::Error for PoissonError {}
+
 impl Poisson {
     /// Constructs a new poisson distribution with a rate (λ)
     /// of `lambda`
@@ -43,9 +60,9 @@ impl Poisson {
     /// result = Poisson::new(0.0);
     /// assert!(result.is_err());
     /// ```
-    pub fn new(lambda: f64) -> Result<Poisson> {
+    pub fn new(lambda: f64) -> Result<Poisson, PoissonError> {
         if lambda.is_nan() || lambda <= 0.0 {
-            Err(StatsError::BadParams)
+            Err(PoissonError::LambdaInvalid)
         } else {
             Ok(Poisson { lambda })
         }
@@ -308,7 +325,7 @@ mod tests {
     use crate::distribution::internal::*;
     use crate::testing_boiler;
 
-    testing_boiler!(lambda: f64; Poisson; StatsError);
+    testing_boiler!(lambda: f64; Poisson; PoissonError);
 
     #[test]
     fn test_create() {

--- a/src/distribution/poisson.rs
+++ b/src/distribution/poisson.rs
@@ -32,6 +32,7 @@ pub enum PoissonError {
 }
 
 impl std::fmt::Display for PoissonError {
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             PoissonError::LambdaInvalid => write!(f, "Lambda is NaN, zero or less than zero"),

--- a/src/distribution/students_t.rs
+++ b/src/distribution/students_t.rs
@@ -421,14 +421,12 @@ impl Continuous<f64, f64> for StudentsT {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use crate::consts::ACC;
     use crate::distribution::internal::*;
-    use crate::distribution::{Continuous, ContinuousCDF, StudentsT};
-    use crate::statistics::*;
     use crate::testing_boiler;
-    use std::panic;
 
-    testing_boiler!(location: f64, scale: f64, freedom: f64; StudentsT);
+    testing_boiler!(location: f64, scale: f64, freedom: f64; StudentsT; StatsError);
 
     #[test]
     fn test_create() {

--- a/src/distribution/students_t.rs
+++ b/src/distribution/students_t.rs
@@ -40,6 +40,7 @@ pub enum StudentsTError {
 }
 
 impl std::fmt::Display for StudentsTError {
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             StudentsTError::LocationInvalid => write!(f, "Location is NaN"),

--- a/src/distribution/triangular.rs
+++ b/src/distribution/triangular.rs
@@ -347,12 +347,11 @@ fn sample_unchecked<R: Rng + ?Sized>(rng: &mut R, min: f64, max: f64, mode: f64)
 #[rustfmt::skip]
 #[cfg(test)]
 mod tests {
-    use crate::distribution::{ContinuousCDF, Continuous, Triangular};
+    use super::*;
     use crate::distribution::internal::*;
-    use crate::statistics::*;
     use crate::testing_boiler;
 
-    testing_boiler!(min: f64, max: f64, mode: f64; Triangular);
+    testing_boiler!(min: f64, max: f64, mode: f64; Triangular; StatsError);
 
     #[test]
     fn test_create() {

--- a/src/distribution/triangular.rs
+++ b/src/distribution/triangular.rs
@@ -45,6 +45,7 @@ pub enum TriangularError {
 }
 
 impl std::fmt::Display for TriangularError {
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             TriangularError::MinInvalid => write!(f, "Minimum is NaN or infinite."),

--- a/src/distribution/uniform.rs
+++ b/src/distribution/uniform.rs
@@ -40,6 +40,7 @@ pub enum UniformError {
 }
 
 impl std::fmt::Display for UniformError {
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             UniformError::MinInvalid => write!(f, "Minimum is NaN or infinite"),

--- a/src/distribution/uniform.rs
+++ b/src/distribution/uniform.rs
@@ -284,12 +284,11 @@ impl Continuous<f64, f64> for Uniform {
 #[rustfmt::skip]
 #[cfg(test)]
 mod tests {
-    use crate::distribution::{ContinuousCDF, Continuous, Uniform};
+    use super::*;
     use crate::distribution::internal::*;
-    use crate::statistics::*;
     use crate::testing_boiler;
 
-    testing_boiler!(min: f64, max: f64; Uniform);
+    testing_boiler!(min: f64, max: f64; Uniform; StatsError);
 
     #[test]
     fn test_create() {

--- a/src/distribution/weibull.rs
+++ b/src/distribution/weibull.rs
@@ -39,6 +39,7 @@ pub enum WeibullError {
 }
 
 impl std::fmt::Display for WeibullError {
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             WeibullError::ShapeInvalid => write!(f, "Shape is NaN, zero or less than zero."),

--- a/src/distribution/weibull.rs
+++ b/src/distribution/weibull.rs
@@ -350,12 +350,11 @@ impl Continuous<f64, f64> for Weibull {
 #[rustfmt::skip]
 #[cfg(test)]
 mod tests {
-    use crate::distribution::{ContinuousCDF, Continuous, Weibull};
+    use super::*;
     use crate::distribution::internal::*;
-    use crate::statistics::*;
     use crate::testing_boiler;
 
-    testing_boiler!(shape: f64, scale: f64; Weibull);
+    testing_boiler!(shape: f64, scale: f64; Weibull; StatsError);
 
     #[test]
     fn test_create() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@
 #![allow(clippy::excessive_precision)]
 #![allow(clippy::many_single_char_names)]
 #![forbid(unsafe_code)]
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 
 #[macro_use]
 extern crate approx;

--- a/src/stats_tests/fisher.rs
+++ b/src/stats_tests/fisher.rs
@@ -105,6 +105,7 @@ pub enum FishersExactTestError {
 }
 
 impl std::fmt::Display for FishersExactTestError {
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             FishersExactTestError::TableInvalidForHypergeometric(hg_err) => {


### PR DESCRIPTION
See https://github.com/statrs-dev/statrs/issues/221#issuecomment-2291250694.

Ignore the massive amount of commits, that's for my organisation and can/will be squashed later.

Outstanding issues:
- [x] ~~Clippy (`Empirical`): Returning a `Result<_, ()>` is not best practice. clippy suggests an `Option` which makes less sense here, so either ignore or return a `Empirical` directly (the function is infallible)~~ ignored

- [x] ~~`MultinomialError` has not been implemented (yet). I noticed that the parameter validation is moved to the `internal` module which implies the `check_multinomial` function will be reused somewhere else, so I didn't want to start changing stuff before that project is done~~ Changed my mind on this. Should be fine to change, it's not much code to replicate inside `new` (e.g. Categorical does basically the same check inside `new`)

- [x] Unit Tests
- [x] Proofread
- [ ] After everything is done: Check `StatsError` to see where it is still used and if it can be replaced by something else 