### PR TITLE
Make nalgebra optional

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Run cargo clippy
         run: cargo clippy --all-targets
 
+      - name: Run cargo clippy without default features
+        run: cargo clippy --no-default-features --all-targets
+
   fmt:
     runs-on: ubuntu-latest
     steps:
@@ -48,5 +51,5 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Test default features
-        run: cargo test --all-targets
+        run: cargo test
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,13 +17,26 @@ include = ["CHANGELOG.md", "LICENSE.md", "src/", "tests/"]
 name = "statrs"
 path = "src/lib.rs"
 
+[features]
+default = ["nalgebra"]
+nalgebra = ["dep:nalgebra"]
+
 [dependencies]
 rand = "0.8"
-nalgebra = { version = "0.32", default-features = false, features = ["rand", "std"] }
 approx = "0.5.0"
 num-traits = "0.2.14"
+
+[dependencies.nalgebra]
+version = "0.32"
+optional = true
+default-features = false
+features = ["rand", "std"]
 
 [dev-dependencies]
 criterion = "0.3.3"
 anyhow = "1.0"
-nalgebra = { version = "0.32", default-features = false, features = ["macros"] }
+
+[dev-dependencies.nalgebra]
+version = "0.32"
+default-features = false
+features = ["macros"]

--- a/src/distribution/internal.rs
+++ b/src/distribution/internal.rs
@@ -1,7 +1,4 @@
-use nalgebra::{Dim, OVector};
 use num_traits::Num;
-
-use crate::StatsError;
 
 /// Returns true if there are no elements in `x` in `arr`
 /// such that `x <= 0.0` or `x` is `f64::NAN` and `sum(arr) > 0.0`.
@@ -17,11 +14,17 @@ pub fn is_valid_multinomial(arr: &[f64], incl_zero: bool) -> bool {
     sum != 0.0
 }
 
+#[cfg(feature = "nalgebra")]
+use nalgebra::{Dim, OVector};
+
+#[cfg(feature = "nalgebra")]
 pub fn check_multinomial<D>(arr: &OVector<f64, D>, accept_zeroes: bool) -> crate::Result<()>
 where
     D: Dim,
     nalgebra::DefaultAllocator: nalgebra::allocator::Allocator<f64, D>,
 {
+    use crate::StatsError;
+
     if arr.len() < 2 {
         return Err(StatsError::BadParams);
     }
@@ -253,6 +256,7 @@ pub mod test {
         check_sum_pmf_is_cdf(dist, x_max);
     }
 
+    #[cfg(feature = "nalgebra")]
     #[test]
     fn test_is_valid_multinomial() {
         use std::f64;

--- a/src/distribution/mod.rs
+++ b/src/distribution/mod.rs
@@ -13,6 +13,7 @@ pub use self::cauchy::Cauchy;
 pub use self::chi::Chi;
 pub use self::chi_squared::ChiSquared;
 pub use self::dirac::Dirac;
+#[cfg(feature = "nalgebra")]
 pub use self::dirichlet::Dirichlet;
 pub use self::discrete_uniform::DiscreteUniform;
 pub use self::empirical::Empirical;
@@ -25,8 +26,11 @@ pub use self::hypergeometric::Hypergeometric;
 pub use self::inverse_gamma::InverseGamma;
 pub use self::laplace::Laplace;
 pub use self::log_normal::LogNormal;
+#[cfg(feature = "nalgebra")]
 pub use self::multinomial::Multinomial;
+#[cfg(feature = "nalgebra")]
 pub use self::multivariate_normal::MultivariateNormal;
+#[cfg(feature = "nalgebra")]
 pub use self::multivariate_students_t::MultivariateStudent;
 pub use self::negative_binomial::NegativeBinomial;
 pub use self::normal::Normal;
@@ -45,6 +49,7 @@ mod cauchy;
 mod chi;
 mod chi_squared;
 mod dirac;
+#[cfg(feature = "nalgebra")]
 mod dirichlet;
 mod discrete_uniform;
 mod empirical;
@@ -59,8 +64,11 @@ mod internal;
 mod inverse_gamma;
 mod laplace;
 mod log_normal;
+#[cfg(feature = "nalgebra")]
 mod multinomial;
+#[cfg(feature = "nalgebra")]
 mod multivariate_normal;
+#[cfg(feature = "nalgebra")]
 mod multivariate_students_t;
 mod negative_binomial;
 mod normal;


### PR DESCRIPTION
Closes #196.

With this, users can remove the `nalgebra` dependency by changing:

```toml
[dependencies]
statrs = "0.17"
```

to

```toml
[dependencies]
statrs = { version = "0.17", default-features = false }
```

This will exclude all distributions depending on `nalgebra` from compilation (and the public API):

```sh
$ cargo public-api --no-default-features | grep -c nalgebra
0
```

There has been some talk in the linked issue about adding a feature for multivariate distributions, but I think for now it's simple enough to hide all nalgebra-dependent types behind this flag. If it becomes necessary, this can still be changed.

The new feature is enabled by default to avoid breakage when upgrading the package, but it probably wouldn't be a big deal to disable it by default either.

MSRV-related note: The `dep:` prefix requires 1.60.