### PR TITLE
Fix several rustdoc warnings

### DIFF
--- a/src/distribution/gamma.rs
+++ b/src/distribution/gamma.rs
@@ -365,15 +365,11 @@ impl Continuous<f64, f64> for Gamma {
 }
 /// Samples from a gamma distribution with a shape of `shape` and a
 /// rate of `rate` using `rng` as the source of randomness. Implementation from:
-/// <br />
-/// <div>
-/// <i>"A Simple Method for Generating Gamma Variables"</i> - Marsaglia & Tsang
-/// </div>
-/// <div>
+///
+/// _"A Simple Method for Generating Gamma Variables"_ - Marsaglia & Tsang
+///
 /// ACM Transactions on Mathematical Software, Vol. 26, No. 3, September 2000,
 /// Pages 363-372
-/// </div>
-/// <br />
 pub fn sample_unchecked<R: Rng + ?Sized>(rng: &mut R, shape: f64, rate: f64) -> f64 {
     let mut a = shape;
     let mut afix = 1.0;

--- a/src/distribution/hypergeometric.rs
+++ b/src/distribution/hypergeometric.rs
@@ -9,11 +9,7 @@ use std::f64;
 /// Implements the
 /// [Hypergeometric](http://en.wikipedia.org/wiki/Hypergeometric_distribution)
 /// distribution
-///
-/// # Examples
-///
-/// ```
-/// ```
+// TODO: Add examples
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub struct Hypergeometric {
     population: u64,
@@ -155,9 +151,8 @@ impl DiscreteCDF<u64, f64> for Hypergeometric {
     /// ```
     ///
     /// where `N` is population, `K` is successes, `n` is draws,
-    /// and `p_F_q` is the [generalized hypergeometric
-    /// function](https://en.wikipedia.
-    /// org/wiki/Generalized_hypergeometric_function)
+    /// and `p_F_q` is the
+    /// [generalized hypergeometric function](https://en.wikipedia.org/wiki/Generalized_hypergeometric_function)
     ///
     /// Calculated as a discrete integral over the probability mass
     /// function evaluated from 0..x+1
@@ -189,9 +184,8 @@ impl DiscreteCDF<u64, f64> for Hypergeometric {
     /// ```
     ///
     /// where `N` is population, `K` is successes, `n` is draws,
-    /// and `p_F_q` is the [generalized hypergeometric
-    /// function](https://en.wikipedia.
-    /// org/wiki/Generalized_hypergeometric_function)
+    /// and `p_F_q` is the
+    /// [generalized hypergeometric function](https://en.wikipedia.org/wiki/Generalized_hypergeometric_function)
     ///
     /// Calculated as a discrete integral over the probability mass
     /// function evaluated from (x+1)..max

--- a/src/function/exponential.rs
+++ b/src/function/exponential.rs
@@ -14,26 +14,18 @@ use crate::{consts, Result, StatsError};
 /// # Remarks
 ///
 /// This implementation follows the derivation in
-/// <br />
-/// <div>
-/// <i>"Handbook of Mathematical Functions, Applied Mathematics Series, Volume
-/// 55"</i> - Abramowitz, M., and Stegun, I.A 1964
-/// </div>
+///
+/// _"Handbook of Mathematical Functions, Applied Mathematics Series, Volume
+/// 55"_ - Abramowitz, M., and Stegun, I.A 1964
+///
 /// AND
-/// <br />
-/// <div>
-/// <i>"Advanced mathematical methods for scientists and engineers" - Bender,
+///
+/// _"Advanced mathematical methods for scientists and engineers"_ - Bender,
 /// Carl M.; Steven A. Orszag (1978). page 253
-/// </div>
-/// <br />
-/// The continued fraction approac is used for `x > 1.0` while the taylor
-/// series expansions
-/// is used for `0.0 < x <= 1`
 ///
-/// # Examples
-///
-/// ```
-/// ```
+/// The continued fraction approach is used for `x > 1.0` while the taylor
+/// series expansions is used for `0.0 < x <= 1`.
+// TODO: Add examples
 pub fn integral(x: f64, n: u64) -> Result<f64> {
     let eps = 0.00000000000000001;
     let max_iter = 100;

--- a/src/stats_tests/fisher.rs
+++ b/src/stats_tests/fisher.rs
@@ -98,7 +98,7 @@ fn binary_search(
 }
 
 /// Perform a Fisher exact test on a 2x2 contingency table.
-/// Based on scipy's fisher test: https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.fisher_exact.html#scipy-stats-fisher-exact
+/// Based on scipy's fisher test: <https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.fisher_exact.html#scipy-stats-fisher-exact>
 /// Expects a table in row-major order
 /// Returns the [odds ratio](https://en.wikipedia.org/wiki/Odds_ratio) and p_value
 /// # Examples
@@ -133,7 +133,7 @@ pub fn fishers_exact_with_odds_ratio(
 }
 
 /// Perform a Fisher exact test on a 2x2 contingency table.
-/// Based on scipy's fisher test: https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.fisher_exact.html#scipy-stats-fisher-exact
+/// Based on scipy's fisher test: <https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.fisher_exact.html#scipy-stats-fisher-exact>
 /// Expects a table in row-major order
 /// Returns only the p_value
 /// # Examples


### PR DESCRIPTION
See `cargo doc` for the warnings. Just some trivial things, like URLs broken across multiple lines and empty code blocks.