### PR TITLE
fix: missing/moved type import after auto-merge

### DIFF
--- a/src/distribution/internal.rs
+++ b/src/distribution/internal.rs
@@ -277,9 +277,9 @@ pub mod test {
     }
 
     pub mod boiler_tests {
-        use super::*;
         use crate::distribution::Binomial;
         use crate::statistics::*;
+        use crate::StatsError;
 
         testing_boiler!(p: f64, n: u64; Binomial);
 


### PR DESCRIPTION
#269 was merged after #270 without a manual rebase/merge, resulting in a slightly broken automatic merge. This should fix everything