### PR TITLE
feat: experiment for reusing allocated buffers for Dyn multivariate

### DIFF
--- a/src/distribution/bernoulli.rs
+++ b/src/distribution/bernoulli.rs
@@ -79,6 +79,7 @@ impl Bernoulli {
 }
 
 impl std::fmt::Display for Bernoulli {
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "Bernoulli({})", self.p())
     }

--- a/src/distribution/chi_squared.rs
+++ b/src/distribution/chi_squared.rs
@@ -95,6 +95,7 @@ impl ChiSquared {
 }
 
 impl std::fmt::Display for ChiSquared {
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "χ^2_{}", self.freedom)
     }

--- a/src/distribution/erlang.rs
+++ b/src/distribution/erlang.rs
@@ -77,6 +77,7 @@ impl Erlang {
 }
 
 impl std::fmt::Display for Erlang {
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "E({}, {})", self.rate(), self.shape())
     }

--- a/src/distribution/multivariate_normal.rs
+++ b/src/distribution/multivariate_normal.rs
@@ -9,7 +9,7 @@ use std::f64::consts::{E, PI};
 /// # Panics
 /// will panic on dimension mismatch
 #[inline]
-pub(super) fn pdf_exponent_unchecked<D>(
+pub(super) fn pdf_exponent<D>(
     mu: &OVector<f64, D>,
     precision: &OMatrix<f64, D, D>,
     x: &OVector<f64, D>,
@@ -23,11 +23,11 @@ where
     -0.5 * (precision * &dv).dot(&dv)
 }
 
-/// computes the argument of the normalization term in the normal distribution
+/// computes normalization term in the normal distribution
 /// # Panics
 /// will panic on dimension mismatch
 #[inline]
-pub(super) fn pdf_const_unchecked<D>(mu: &OVector<f64, D>, cov: &OMatrix<f64, D, D>) -> f64
+pub(super) fn pdf_const<D>(mu: &OVector<f64, D>, cov: &OMatrix<f64, D, D>) -> f64
 where
     D: DimMin<D, Output = D>,
     nalgebra::DefaultAllocator: nalgebra::allocator::Allocator<f64, D>
@@ -165,7 +165,7 @@ where
             cov_chol @ Some(_) => Ok(MultivariateNormal {
                 precision: cov_chol.as_ref().map(|ll| ll.inverse()),
                 cov_chol,
-                pdf_const: pdf_const_unchecked(&mean, &cov),
+                pdf_const: pdf_const(&mean, &cov),
                 mu: mean,
                 cov,
             }),
@@ -400,13 +400,13 @@ where
     /// where `μ` is the mean, `inv(Σ)` is the precision matrix, `det(Σ)` is the determinant
     /// of the covariance matrix, and `k` is the dimension of the distribution
     fn pdf(&self, x: &OVector<f64, D>) -> f64 {
-        self.pdf_const * pdf_exponent_unchecked(&self.mu, self.precision.as_ref().unwrap(), x).exp()
+        self.pdf_const * pdf_exponent(&self.mu, self.precision.as_ref().unwrap(), x).exp()
     }
 
     /// Calculates the log probability density function for the multivariate
     /// normal distribution at `x`. Equivalent to pdf(x).ln().
     fn ln_pdf(&self, x: &OVector<f64, D>) -> f64 {
-        self.pdf_const.ln() + pdf_exponent_unchecked(&self.mu, self.precision.as_ref().unwrap(), x)
+        self.pdf_const.ln() + pdf_exponent(&self.mu, self.precision.as_ref().unwrap(), x)
     }
 }
 

--- a/src/distribution/multivariate_students_t.rs
+++ b/src/distribution/multivariate_students_t.rs
@@ -346,14 +346,9 @@ where
     /// of the scale matrix, and `k` is the dimension of the distribution.
     fn pdf(&self, x: &'a OVector<f64, D>) -> f64 {
         if self.freedom.is_infinite() {
-            use super::multivariate_normal::density_normalization_and_exponential;
-            let (pdf_const, exp_arg) = density_normalization_and_exponential(
-                &self.location,
-                &self.scale,
-                &self.precision,
-                x,
-            )
-            .unwrap();
+            use super::multivariate_normal as mvn;
+            let pdf_const = mvn::pdf_const_unchecked(&self.location, &self.scale);
+            let exp_arg = mvn::pdf_exponent_unchecked(&self.location, &self.precision, x);
             return pdf_const * exp_arg.exp();
         }
 
@@ -367,14 +362,9 @@ where
     /// student distribution at `x`. Equivalent to pdf(x).ln().
     fn ln_pdf(&self, x: &'a OVector<f64, D>) -> f64 {
         if self.freedom.is_infinite() {
-            use super::multivariate_normal::density_normalization_and_exponential;
-            let (pdf_const, exp_arg) = density_normalization_and_exponential(
-                &self.location,
-                &self.scale,
-                &self.precision,
-                x,
-            )
-            .unwrap();
+            use super::multivariate_normal as mvn;
+            let pdf_const = mvn::pdf_const_unchecked(&self.location, &self.scale);
+            let exp_arg = mvn::pdf_exponent_unchecked(&self.location, &self.precision, x);
             return pdf_const.ln() + exp_arg;
         }
 

--- a/src/distribution/multivariate_students_t.rs
+++ b/src/distribution/multivariate_students_t.rs
@@ -347,8 +347,8 @@ where
     fn pdf(&self, x: &'a OVector<f64, D>) -> f64 {
         if self.freedom.is_infinite() {
             use super::multivariate_normal as mvn;
-            let pdf_const = mvn::pdf_const_unchecked(&self.location, &self.scale);
-            let exp_arg = mvn::pdf_exponent_unchecked(&self.location, &self.precision, x);
+            let pdf_const = mvn::pdf_const(&self.location, &self.scale);
+            let exp_arg = mvn::pdf_exponent(&self.location, &self.precision, x);
             return pdf_const * exp_arg.exp();
         }
 
@@ -363,8 +363,8 @@ where
     fn ln_pdf(&self, x: &'a OVector<f64, D>) -> f64 {
         if self.freedom.is_infinite() {
             use super::multivariate_normal as mvn;
-            let pdf_const = mvn::pdf_const_unchecked(&self.location, &self.scale);
-            let exp_arg = mvn::pdf_exponent_unchecked(&self.location, &self.precision, x);
+            let pdf_const = mvn::pdf_const(&self.location, &self.scale);
+            let exp_arg = mvn::pdf_exponent(&self.location, &self.precision, x);
             return pdf_const.ln() + exp_arg;
         }
 


### PR DESCRIPTION
takes approach of making a few fields `OnceCell`, allowing for init-ing
precomputed values while allow taking them out to modify without
reallocate

Implementing similar way to update location via `set` or `set_with` would also be implemented.
Would also implement nearly identical in StudentsT.
