### PR TITLE
Inline string formatting arguments when possible

### DIFF
--- a/src/distribution/chi.rs
+++ b/src/distribution/chi.rs
@@ -381,7 +381,7 @@ mod tests {
     fn test_large_dof_mean_not_nan() {
         for i in 1..1000 {
             let mean = Chi::new(i as f64).unwrap().mean().unwrap();
-            assert!(!mean.is_nan(), "Chi mean for {} dof was {}", i, mean);
+            assert!(!mean.is_nan(), "Chi mean for {i} dof was {mean}");
         }
     }
 

--- a/src/distribution/empirical.rs
+++ b/src/distribution/empirical.rs
@@ -159,13 +159,13 @@ impl std::fmt::Display for Empirical {
             .flat_map(|(&NonNan(x), &count)| std::iter::repeat(x).take(count as usize));
 
         if let Some(x) = enumerated_values.next() {
-            write!(f, "Empirical([{:.3e}", x)?;
+            write!(f, "Empirical([{x:.3e}")?;
         } else {
             return write!(f, "Empirical(∅)");
         }
 
         for val in enumerated_values.by_ref().take(4) {
-            write!(f, ", {:.3e}", val)?;
+            write!(f, ", {val:.3e}")?;
         }
         if enumerated_values.next().is_some() {
             write!(f, ", ...")?;

--- a/src/distribution/internal.rs
+++ b/src/distribution/internal.rs
@@ -377,8 +377,8 @@ pub mod test {
             let cdf = dist.cdf(x);
             if (sum - cdf).abs() > 1e-3 {
                 println!("Integral of pdf doesn't equal cdf!");
-                println!("Integration from {} by {} to {} = {}", x_min, step, x, sum);
-                println!("cdf = {}", cdf);
+                println!("Integration from {x_min} by {step} to {x} = {sum}");
+                println!("cdf = {cdf}");
                 panic!();
             }
 

--- a/src/distribution/laplace.rs
+++ b/src/distribution/laplace.rs
@@ -588,9 +588,7 @@ mod tests {
             });
             assert!(
                 result > -tolerance && result < tolerance,
-                "Balance is {} for seed {}",
-                result,
-                seed
+                "Balance is {result} for seed {seed}"
             );
         }
     }

--- a/src/distribution/uniform.rs
+++ b/src/distribution/uniform.rs
@@ -168,7 +168,7 @@ impl ContinuousCDF<f64, f64> for Uniform {
     /// Finds the value of `x` where `F(p) = x`
     fn inverse_cdf(&self, p: f64) -> f64 {
         if !(0.0..=1.0).contains(&p) {
-            panic!("p must be in [0, 1], was {}", p);
+            panic!("p must be in [0, 1], was {p}");
         } else if p == 0.0 {
             self.min
         } else if p == 1.0 {

--- a/src/error.rs
+++ b/src/error.rs
@@ -56,50 +56,50 @@ impl fmt::Display for StatsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             StatsError::BadParams => write!(f, "Bad distribution parameters"),
-            StatsError::ArgFinite(s) => write!(f, "Argument {} must be finite", s),
-            StatsError::ArgMustBePositive(s) => write!(f, "Argument {} must be positive", s),
-            StatsError::ArgNotNegative(s) => write!(f, "Argument {} must be non-negative", s),
+            StatsError::ArgFinite(s) => write!(f, "Argument {s} must be finite"),
+            StatsError::ArgMustBePositive(s) => write!(f, "Argument {s} must be positive"),
+            StatsError::ArgNotNegative(s) => write!(f, "Argument {s} must be non-negative"),
             StatsError::ArgIntervalIncl(s, min, max) => {
-                write!(f, "Argument {} not within interval [{}, {}]", s, min, max)
+                write!(f, "Argument {s} not within interval [{min}, {max}]")
             }
             StatsError::ArgIntervalExcl(s, min, max) => {
-                write!(f, "Argument {} not within interval ({}, {})", s, min, max)
+                write!(f, "Argument {s} not within interval ({min}, {max})")
             }
             StatsError::ArgIntervalExclMin(s, min, max) => {
-                write!(f, "Argument {} not within interval ({}, {}]", s, min, max)
+                write!(f, "Argument {s} not within interval ({min}, {max}]")
             }
             StatsError::ArgIntervalExclMax(s, min, max) => {
-                write!(f, "Argument {} not within interval [{}, {})", s, min, max)
+                write!(f, "Argument {s} not within interval [{min}, {max})")
             }
-            StatsError::ArgGt(s, val) => write!(f, "Argument {} must be greater than {}", s, val),
+            StatsError::ArgGt(s, val) => write!(f, "Argument {s} must be greater than {val}"),
             StatsError::ArgGtArg(s, val) => {
-                write!(f, "Argument {} must be greater than {}", s, val)
+                write!(f, "Argument {s} must be greater than {val}")
             }
             StatsError::ArgGte(s, val) => {
-                write!(f, "Argument {} must be greater than or equal to {}", s, val)
+                write!(f, "Argument {s} must be greater than or equal to {val}")
             }
             StatsError::ArgGteArg(s, val) => {
-                write!(f, "Argument {} must be greater than or equal to {}", s, val)
+                write!(f, "Argument {s} must be greater than or equal to {val}")
             }
-            StatsError::ArgLt(s, val) => write!(f, "Argument {} must be less than {}", s, val),
-            StatsError::ArgLtArg(s, val) => write!(f, "Argument {} must be less than {}", s, val),
+            StatsError::ArgLt(s, val) => write!(f, "Argument {s} must be less than {val}"),
+            StatsError::ArgLtArg(s, val) => write!(f, "Argument {s} must be less than {val}"),
             StatsError::ArgLte(s, val) => {
-                write!(f, "Argument {} must be less than or equal to {}", s, val)
+                write!(f, "Argument {s} must be less than or equal to {val}")
             }
             StatsError::ArgLteArg(s, val) => {
-                write!(f, "Argument {} must be less than or equal to {}", s, val)
+                write!(f, "Argument {s} must be less than or equal to {val}")
             }
             StatsError::ContainersMustBeSameLength => {
                 write!(f, "Expected containers of same length")
             }
             StatsError::ComputationFailedToConverge => write!(f, "Computation failed to converge"),
             StatsError::ContainerExpectedSum(s, sum) => {
-                write!(f, "Elements in container {} expected to sum to {}", s, sum)
+                write!(f, "Elements in container {s} expected to sum to {sum}")
             }
             StatsError::ContainerExpectedSumVar(s, sum) => {
-                write!(f, "Elements in container {} expected to sum to {}", s, sum)
+                write!(f, "Elements in container {s} expected to sum to {sum}")
             }
-            StatsError::SpecialCase(s) => write!(f, "{}", s),
+            StatsError::SpecialCase(s) => write!(f, "{s}"),
         }
     }
 }

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -83,7 +83,7 @@ impl InfinitePeriodic {
 
 impl std::fmt::Display for InfinitePeriodic {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:#?}", self)
+        write!(f, "{self:#?}")
     }
 }
 

--- a/src/statistics/slice_statistics.rs
+++ b/src/statistics/slice_statistics.rs
@@ -14,11 +14,11 @@ where
         write!(f, "Data([")?;
 
         if let Some(v) = tee.next() {
-            write!(f, "{}", v)?;
+            write!(f, "{v}")?;
         }
         for _ in 1..5 {
             if let Some(v) = tee.next() {
-                write!(f, ", {}", v)?;
+                write!(f, ", {v}")?;
             }
         }
         if tee.next().is_some() {

--- a/src/stats_tests/fisher.rs
+++ b/src/stats_tests/fisher.rs
@@ -111,7 +111,7 @@ impl std::fmt::Display for FishersExactTestError {
             FishersExactTestError::TableInvalidForHypergeometric(hg_err) => {
                 writeln!(f, "Cannot create a Hypergeometric distribution from the data in the contingency table.")?;
                 writeln!(f, "Is it in row-major order?")?;
-                write!(f, "Inner error: '{}'", hg_err)
+                write!(f, "Inner error: '{hg_err}'")
             }
         }
     }

--- a/tests/nist_tests.rs
+++ b/tests/nist_tests.rs
@@ -76,7 +76,7 @@ fn nist_strd_univariate_mean() {
     for fname in FILENAMES {
         let filepath = get_path(fname, env::var(NIST_DATA_DIR_ENV).ok().as_deref());
         let case = parse_file(filepath)
-            .unwrap_or_else(|e| panic!("failed parsing file {} with `{:?}`", fname, e));
+            .unwrap_or_else(|e| panic!("failed parsing file {fname} with `{e:?}`"));
         assert_relative_eq!(case.values.mean(), case.certified.mean, epsilon = 1e-12);
     }
 }
@@ -87,7 +87,7 @@ fn nist_strd_univariate_std_dev() {
     for fname in FILENAMES {
         let filepath = get_path(fname, env::var(NIST_DATA_DIR_ENV).ok().as_deref());
         let case = parse_file(filepath)
-            .unwrap_or_else(|e| panic!("failed parsing file {} with `{:?}`", fname, e));
+            .unwrap_or_else(|e| panic!("failed parsing file {fname} with `{e:?}`"));
         assert_relative_eq!(
             case.values.std_dev(),
             case.certified.std_dev,


### PR DESCRIPTION
This has been [stable since 1.58.0](https://github.com/rust-lang/rust/pull/90473/), and since it's unlikely that the MSRV will reduce below 1.61, I think it's fine to change this because it increases readability.

clippy also has a lint for this (`uninlined_format_args`), but that might be overkill.