### PR TITLE
Replace all instances of `StatsError` with custom error types or `Option<T>`

### DIFF
--- a/src/distribution/multivariate_students_t.rs
+++ b/src/distribution/multivariate_students_t.rs
@@ -340,10 +340,13 @@ where
     /// [Γ(ν+p)/2] / [Γ(ν/2) ((ν * π)^p det(Σ))^(1 / 2)] * [1 + 1/ν (x - μ)ᵀ inv(Σ) (x - μ)]^(-(ν+p)/2)
     /// ```
     ///
-    /// where `ν` is the degrees of freedom,  `μ` is the mean, `Γ`
-    /// is the Gamma function, `inv(Σ)`
-    /// is the precision matrix, `det(Σ)` is the determinant
-    /// of the scale matrix, and `k` is the dimension of the distribution.
+    /// where
+    /// - `ν` is the degrees of freedom,
+    /// - `μ` is the mean,
+    /// - `Γ` is the Gamma function,
+    /// - `inv(Σ)` is the precision matrix,
+    /// - `det(Σ)` is the determinant of the scale matrix, and
+    /// - `k` is the dimension of the distribution.
     fn pdf(&self, x: &'a OVector<f64, D>) -> f64 {
         if self.freedom.is_infinite() {
             use super::multivariate_normal::density_normalization_and_exponential;

--- a/src/function/exponential.rs
+++ b/src/function/exponential.rs
@@ -1,14 +1,12 @@
 //! Provides functions related to exponential calculations
 
-use crate::{consts, Result, StatsError};
+use crate::consts;
 
 /// Computes the generalized Exponential Integral function
 /// where `x` is the argument and `n` is the integer power of the
 /// denominator term.
 ///
-/// # Errors
-///
-/// Returns an error if `x < 0.0` or the computation could not
+/// Returns `None` if `x < 0.0` or the computation could not
 /// converge after 100 iterations
 ///
 /// # Remarks
@@ -26,7 +24,7 @@ use crate::{consts, Result, StatsError};
 /// The continued fraction approach is used for `x > 1.0` while the taylor
 /// series expansions is used for `0.0 < x <= 1`.
 // TODO: Add examples
-pub fn integral(x: f64, n: u64) -> Result<f64> {
+pub fn integral(x: f64, n: u64) -> Option<f64> {
     let eps = 0.00000000000000001;
     let max_iter = 100;
     let nf64 = n as f64;
@@ -34,10 +32,10 @@ pub fn integral(x: f64, n: u64) -> Result<f64> {
 
     // special cases
     if n == 0 {
-        return Ok((-1.0 * x).exp() / x);
+        return Some((-1.0 * x).exp() / x);
     }
     if x == 0.0 {
-        return Ok(1.0 / (nf64 - 1.0));
+        return Some(1.0 / (nf64 - 1.0));
     }
 
     if x > 1.0 {
@@ -53,10 +51,10 @@ pub fn integral(x: f64, n: u64) -> Result<f64> {
             let del = c * d;
             h *= del;
             if (del - 1.0).abs() < eps {
-                return Ok(h * (-x).exp());
+                return Some(h * (-x).exp());
             }
         }
-        Err(StatsError::ComputationFailedToConverge)
+        None
     } else {
         let mut factorial = 1.0;
         let mut result = if n - 1 != 0 {
@@ -77,10 +75,10 @@ pub fn integral(x: f64, n: u64) -> Result<f64> {
             };
             result += del;
             if del.abs() < result.abs() * eps {
-                return Ok(result);
+                return Some(result);
             }
         }
-        Err(StatsError::ComputationFailedToConverge)
+        None
     }
 }
 

--- a/src/function/factorial.rs
+++ b/src/function/factorial.rs
@@ -1,9 +1,7 @@
 //! Provides functions related to factorial calculations (e.g. binomial
 //! coefficient, factorial, multinomial)
 
-use crate::error::StatsError;
 use crate::function::gamma;
-use crate::Result;
 
 /// The maximum factorial representable
 /// by a 64-bit floating point without
@@ -74,17 +72,16 @@ pub fn multinomial(n: u64, ni: &[u64]) -> f64 {
 
 /// Computes the multinomial coefficient: `n choose n1, n2, n3, ...`
 ///
-/// # Errors
-///
-/// If the elements in `ni` do not sum to `n`
-pub fn checked_multinomial(n: u64, ni: &[u64]) -> Result<f64> {
+/// Returns `None` if the elements in `ni` do not sum to `n`.
+pub fn checked_multinomial(n: u64, ni: &[u64]) -> Option<f64> {
     let (sum, ret) = ni.iter().fold((0, ln_factorial(n)), |acc, &x| {
         (acc.0 + x, acc.1 - ln_factorial(x))
     });
-    if sum != n {
-        Err(StatsError::ContainerExpectedSumVar("ni", "n"))
+
+    if sum == n {
+        Some((0.5 + ret.exp()).floor())
     } else {
-        Ok((0.5 + ret.exp()).floor())
+        None
     }
 }
 
@@ -179,6 +176,6 @@ mod tests {
 
     #[test]
     fn test_checked_multinomial_bad_ni() {
-        assert!(checked_multinomial(1, &[1, 1]).is_err());
+        assert!(checked_multinomial(1, &[1, 1]).is_none());
     }
 }

--- a/src/function/logistic.rs
+++ b/src/function/logistic.rs
@@ -1,9 +1,6 @@
 //! Provides the [logistic](http://en.wikipedia.org/wiki/Logistic_function) and
 //! related functions
 
-use crate::error::StatsError;
-use crate::Result;
-
 /// Computes the logistic function
 pub fn logistic(p: f64) -> f64 {
     1.0 / ((-p).exp() + 1.0)
@@ -18,16 +15,12 @@ pub fn logit(p: f64) -> f64 {
     checked_logit(p).unwrap()
 }
 
-/// Computes the logit function
-///
-/// # Errors
-///
-/// If `p < 0.0` or `p > 1.0`
-pub fn checked_logit(p: f64) -> Result<f64> {
-    if !(0.0..=1.0).contains(&p) {
-        Err(StatsError::ArgIntervalIncl("p", 0.0, 1.0))
+/// Computes the logit function, returning `None` if `p < 0.0` or `p > 1.0`.
+pub fn checked_logit(p: f64) -> Option<f64> {
+    if (0.0..=1.0).contains(&p) {
+        Some((p / (1.0 - p)).ln())
     } else {
-        Ok((p / (1.0 - p)).ln())
+        None
     }
 }
 
@@ -76,11 +69,11 @@ mod tests {
 
     #[test]
     fn test_checked_logit_p_lt_0() {
-        assert!(super::checked_logit(-1.0).is_err());
+        assert!(super::checked_logit(-1.0).is_none());
     }
 
     #[test]
     fn test_checked_logit_p_gt_1() {
-        assert!(super::checked_logit(2.0).is_err());
+        assert!(super::checked_logit(2.0).is_none());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,11 +74,3 @@ pub mod generate;
 pub mod prec;
 pub mod statistics;
 pub mod stats_tests;
-
-mod error;
-
-pub use crate::error::StatsError;
-
-/// Result type for the statrs library package that returns
-/// either a result type `T` or a `StatsError`
-pub type Result<T> = std::result::Result<T, StatsError>;

--- a/src/statistics/iter_statistics.rs
+++ b/src/statistics/iter_statistics.rs
@@ -1,4 +1,3 @@
-use crate::error::StatsError;
 use crate::statistics::*;
 use std::borrow::Borrow;
 use std::f64;
@@ -175,7 +174,7 @@ where
         for x in self {
             let borrow = *x.borrow();
             let borrow2 = match iter.next() {
-                None => panic!("{}", StatsError::ContainersMustBeSameLength),
+                None => panic!("Iterators must have the same length"),
                 Some(x) => *x.borrow(),
             };
             let old_mean2 = mean2;
@@ -185,7 +184,7 @@ where
             comoment += (borrow - mean1) * (borrow2 - old_mean2);
         }
         if iter.next().is_some() {
-            panic!("{}", StatsError::ContainersMustBeSameLength);
+            panic!("Iterators must have the same length");
         }
 
         if n > 1.0 {
@@ -205,7 +204,7 @@ where
         for x in self {
             let borrow = *x.borrow();
             let borrow2 = match iter.next() {
-                None => panic!("{}", StatsError::ContainersMustBeSameLength),
+                None => panic!("Iterators must have the same length"),
                 Some(x) => *x.borrow(),
             };
             let old_mean2 = mean2;
@@ -215,7 +214,7 @@ where
             comoment += (borrow - mean1) * (borrow2 - old_mean2);
         }
         if iter.next().is_some() {
-            panic!("{}", StatsError::ContainersMustBeSameLength)
+            panic!("Iterators must have the same length")
         }
         if n > 0.0 {
             comoment / n


### PR DESCRIPTION
Closes #221, I think.

Added some new error types similar to the ones introduced in #265.

Some functions only got the simpler `Option<T>` return type if they only have one error condition. The functions in MultivariateNormal also have a simple Option return type because they're non-public, and it's expected that the preconditions are fulfilled on every call anyways. No need for fancy error messages (and can be easily changed if need be)