### PR TITLE
doc: feature-gate doctest that needs `rand`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,8 @@
 //!
 //! # Sampling
 //! The common use case is to set up the distributions and sample from them which depends on the `Rand` crate for random number generation.
-//! ```
+#![cfg_attr(feature = "rand", doc = "```")]
+#![cfg_attr(not(feature = "rand"), doc = "```ignore")]
 //! use statrs::distribution::Exp;
 //! use rand::distributions::Distribution;
 //! let mut r = rand::rngs::OsRng;


### PR DESCRIPTION
`cargo test --doc --no-default-features` currently fails with a compiler error:

```sh
failures:

---- src/lib.rs - (line 10) stdout ----
error[E0433]: failed to resolve: use of undeclared crate or module `rand`
 --> src/lib.rs:13:5
  |
6 | use rand::distributions::Distribution;
  |     ^^^^ use of undeclared crate or module `rand`

error[E0433]: failed to resolve: use of undeclared crate or module `rand`
 --> src/lib.rs:14:13
  |
7 | let mut r = rand::rngs::OsRng;
  |             ^^^^ use of undeclared crate or module `rand`

error[E0599]: no method named `sample` found for struct `Exp` in the current scope
 --> src/lib.rs:16:16
  |
9 | print!("{}", n.sample(&mut r));
  |                ^^^^^^ method not found in `Exp`

error: aborting due to 3 previous errors

Some errors have detailed explanations: E0433, E0599.
For more information about an error, try `rustc --explain E0433`.
Couldn't compile the test.

failures:
    src/lib.rs - (line 10)
```

This was introduced in #275 and not noticed because CI doesn't run tests on all feature combinations. I think this only affects local doc builds, but it's still annoying that this was missed by CI. But testing all feature combinations with `cargo-hack` and `--feature-powerset` would likely increase the CI time dramatically. Not sure it's worth it since normal compiler errors will get caught by CI, it's just doctests that are not completely covered..