### PR TITLE
fix: Use exp_m1 instead of subtracting directly

### DIFF
--- a/src/distribution/gumbel.rs
+++ b/src/distribution/gumbel.rs
@@ -510,6 +510,8 @@ mod tests {
         test_exact(f64::INFINITY, 1.0, 1.0, sf(0.0));
         test_exact(f64::INFINITY, 1.0, 1.0, sf(1.0));
         test_exact(f64::INFINITY, 1.0, 1.0, sf(5.0));
+        test_absolute(0.0, 1.0, 4.248354255291589e-18, 1e-32, sf(40.0));
+        test_absolute(0.0, 1.0, 1.804851387845415e-35, 1e-50, sf(80.0));
     }
 
     #[test]

--- a/src/distribution/gumbel.rs
+++ b/src/distribution/gumbel.rs
@@ -167,7 +167,7 @@ impl ContinuousCDF<f64, f64> for Gumbel {
     ///
     /// where `μ` is the location and `β` is the scale
     fn sf(&self, x: f64) -> f64 {
-        1.0 - (-(-(x - self.location) / self.scale).exp()).exp()
+        -(-(-(x - self.location) / self.scale).exp()).exp_m1()
     }
 }
 


### PR DESCRIPTION
- Added fix to use exp_m1 function to compute sf for Gumbel distribution more accurately