### PR TITLE
refactor!: forbid α=inf || β=inf in Beta distr.

### DIFF
--- a/src/distribution/internal.rs
+++ b/src/distribution/internal.rs
@@ -323,7 +323,7 @@ pub mod test {
         #[test]
         #[should_panic]
         fn test_create_err_failure() {
-            test_create_err(0.0, 0.5, BetaError::BothShapesInfinite);
+            test_create_err(0.0, 0.5, BetaError::ShapeBInvalid);
         }
 
         #[test]
@@ -340,7 +340,7 @@ pub mod test {
 
         #[test]
         fn test_is_none_success() {
-            test_none(f64::INFINITY, 1.2, |dist| dist.entropy());
+            test_none(0.5, 1.2, |dist| dist.mode());
         }
 
         #[test]


### PR DESCRIPTION
Currently, `new` only rejects both shapes being infinite. Now, it rejects any of the shapes being infinite.

There's been some discussion (#102) about supporting degenerate parameters for distributions. For `Beta` specifically, almost every function (cdf, sf, pdf, mode, mean, ...) needs one or two special cases for infinite parameters, which doesn't seem sensible. For users needing a shape=+/-INF, it makes more sense to create their own struct and then implement the relevant statrs traits, performance- and complexity-wise.

This fixes `skewness()` returning an incorrect value for numeric limits (#136) and simplifies most `Beta` functions.

Also clarifies and fixes up some docs. Breaking because it removes an enum variant from `BetaError`, which is public.