### PR TITLE
Add `#![no_std]` support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Test no_std
+        run: cargo test --no-default-features -F rand
+
       - name: Test default features
         run: cargo test
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,13 @@ path = "src/lib.rs"
 [[bench]]
 name = "order_statistics"
 harness = false
-required-features = ["rand"]
+required-features = ["rand", "std"]
 
 [features]
-default = ["nalgebra", "rand"]
-nalgebra = ["dep:nalgebra"]
+default = ["std", "nalgebra", "rand"]
+std = ["nalgebra?/std", "rand?/std"]
+# at the moment, all nalgebra features needs std
+nalgebra = ["dep:nalgebra", "std"]
 rand = ["dep:rand", "nalgebra?/rand"]
 
 [dependencies]
@@ -36,12 +38,12 @@ num-traits = "0.2.14"
 [dependencies.rand]
 version = "0.8"
 optional = true
+default-features = false
 
 [dependencies.nalgebra]
 version = "0.33"
 optional = true
 default-features = false
-features = ["std"]
 
 [dev-dependencies]
 criterion = "0.5"

--- a/src/distribution/bernoulli.rs
+++ b/src/distribution/bernoulli.rs
@@ -78,8 +78,8 @@ impl Bernoulli {
     }
 }
 
-impl std::fmt::Display for Bernoulli {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for Bernoulli {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "Bernoulli({})", self.p())
     }
 }

--- a/src/distribution/beta.rs
+++ b/src/distribution/beta.rs
@@ -33,9 +33,9 @@ pub enum BetaError {
     ShapeBInvalid,
 }
 
-impl std::fmt::Display for BetaError {
+impl core::fmt::Display for BetaError {
     #[cfg_attr(coverage_nightly, coverage(off))]
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             BetaError::ShapeAInvalid => write!(f, "Shape A is NaN, infinite, zero or negative"),
             BetaError::ShapeBInvalid => write!(f, "Shape B is NaN, infinite, zero or negative"),
@@ -106,8 +106,8 @@ impl Beta {
     }
 }
 
-impl std::fmt::Display for Beta {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for Beta {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "Beta(a={}, b={})", self.shape_a, self.shape_b)
     }
 }

--- a/src/distribution/beta.rs
+++ b/src/distribution/beta.rs
@@ -43,6 +43,7 @@ impl core::fmt::Display for BetaError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for BetaError {}
 
 impl Beta {

--- a/src/distribution/binomial.rs
+++ b/src/distribution/binomial.rs
@@ -1,7 +1,7 @@
 use crate::distribution::{Discrete, DiscreteCDF};
 use crate::function::{beta, factorial};
 use crate::statistics::*;
-use std::f64;
+use core::f64;
 
 /// Implements the
 /// [Binomial](https://en.wikipedia.org/wiki/Binomial_distribution)
@@ -32,9 +32,9 @@ pub enum BinomialError {
     ProbabilityInvalid,
 }
 
-impl std::fmt::Display for BinomialError {
+impl core::fmt::Display for BinomialError {
     #[cfg_attr(coverage_nightly, coverage(off))]
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             BinomialError::ProbabilityInvalid => write!(f, "Probability is NaN or not in [0, 1]"),
         }
@@ -103,8 +103,8 @@ impl Binomial {
     }
 }
 
-impl std::fmt::Display for Binomial {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for Binomial {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "Bin({},{})", self.p, self.n)
     }
 }

--- a/src/distribution/binomial.rs
+++ b/src/distribution/binomial.rs
@@ -41,6 +41,7 @@ impl core::fmt::Display for BinomialError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for BinomialError {}
 
 impl Binomial {

--- a/src/distribution/categorical.rs
+++ b/src/distribution/categorical.rs
@@ -1,6 +1,6 @@
 use crate::distribution::{Discrete, DiscreteCDF};
 use crate::statistics::*;
-use std::f64;
+use core::f64;
 
 /// Implements the
 /// [Categorical](https://en.wikipedia.org/wiki/Categorical_distribution)
@@ -39,9 +39,9 @@ pub enum CategoricalError {
     ProbMassHasInvalidElements,
 }
 
-impl std::fmt::Display for CategoricalError {
+impl core::fmt::Display for CategoricalError {
     #[cfg_attr(coverage_nightly, coverage(off))]
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             CategoricalError::ProbMassEmpty => write!(f, "Probability mass is empty"),
             CategoricalError::ProbMassSumZero => write!(f, "Probabilities sum up to zero"),
@@ -117,8 +117,8 @@ impl Categorical {
     }
 }
 
-impl std::fmt::Display for Categorical {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for Categorical {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "Cat({:#?})", self.norm_pmf)
     }
 }
@@ -371,7 +371,7 @@ pub fn cdf_to_sf(cdf: &[f64]) -> Vec<f64> {
 // return 0. Otherwise val returns the index of the first element larger than
 // it within the search array.
 fn binary_index(search: &[f64], val: f64) -> usize {
-    use std::cmp;
+    use core::cmp;
 
     let mut low = 0_isize;
     let mut high = search.len() as isize - 1;

--- a/src/distribution/categorical.rs
+++ b/src/distribution/categorical.rs
@@ -53,6 +53,7 @@ impl core::fmt::Display for CategoricalError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for CategoricalError {}
 
 impl Categorical {

--- a/src/distribution/cauchy.rs
+++ b/src/distribution/cauchy.rs
@@ -42,6 +42,7 @@ impl core::fmt::Display for CauchyError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for CauchyError {}
 
 impl Cauchy {

--- a/src/distribution/cauchy.rs
+++ b/src/distribution/cauchy.rs
@@ -1,6 +1,6 @@
 use crate::distribution::{Continuous, ContinuousCDF};
 use crate::statistics::*;
-use std::f64;
+use core::f64;
 
 /// Implements the [Cauchy](https://en.wikipedia.org/wiki/Cauchy_distribution)
 /// distribution, also known as the Lorentz distribution.
@@ -32,9 +32,9 @@ pub enum CauchyError {
     ScaleInvalid,
 }
 
-impl std::fmt::Display for CauchyError {
+impl core::fmt::Display for CauchyError {
     #[cfg_attr(coverage_nightly, coverage(off))]
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             CauchyError::LocationInvalid => write!(f, "Location is NaN"),
             CauchyError::ScaleInvalid => write!(f, "Scale is NaN, zero or less than zero"),
@@ -104,8 +104,8 @@ impl Cauchy {
     }
 }
 
-impl std::fmt::Display for Cauchy {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for Cauchy {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "Cauchy({}, {})", self.location, self.scale)
     }
 }

--- a/src/distribution/chi.rs
+++ b/src/distribution/chi.rs
@@ -1,8 +1,8 @@
 use crate::distribution::{Continuous, ContinuousCDF};
 use crate::function::gamma;
 use crate::statistics::*;
-use std::f64;
-use std::num::NonZeroU64;
+use core::f64;
+use core::num::NonZeroU64;
 
 /// Implements the [Chi](https://en.wikipedia.org/wiki/Chi_distribution)
 /// distribution
@@ -31,9 +31,9 @@ pub enum ChiError {
     FreedomInvalid,
 }
 
-impl std::fmt::Display for ChiError {
+impl core::fmt::Display for ChiError {
     #[cfg_attr(coverage_nightly, coverage(off))]
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             ChiError::FreedomInvalid => {
                 write!(f, "Degrees of freedom are zero")
@@ -86,8 +86,8 @@ impl Chi {
     }
 }
 
-impl std::fmt::Display for Chi {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for Chi {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "χ_{}", self.freedom)
     }
 }

--- a/src/distribution/chi.rs
+++ b/src/distribution/chi.rs
@@ -42,6 +42,7 @@ impl core::fmt::Display for ChiError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for ChiError {}
 
 impl Chi {

--- a/src/distribution/chi_squared.rs
+++ b/src/distribution/chi_squared.rs
@@ -1,6 +1,6 @@
 use crate::distribution::{Continuous, ContinuousCDF, Gamma, GammaError};
 use crate::statistics::*;
-use std::f64;
+use core::f64;
 
 /// Implements the
 /// [Chi-squared](https://en.wikipedia.org/wiki/Chi-squared_distribution)
@@ -94,8 +94,8 @@ impl ChiSquared {
     }
 }
 
-impl std::fmt::Display for ChiSquared {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for ChiSquared {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "χ^2_{}", self.freedom)
     }
 }

--- a/src/distribution/dirac.rs
+++ b/src/distribution/dirac.rs
@@ -24,9 +24,9 @@ pub enum DiracError {
     ValueInvalid,
 }
 
-impl std::fmt::Display for DiracError {
+impl core::fmt::Display for DiracError {
     #[cfg_attr(coverage_nightly, coverage(off))]
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             DiracError::ValueInvalid => write!(f, "Value v is NaN"),
         }
@@ -62,8 +62,8 @@ impl Dirac {
     }
 }
 
-impl std::fmt::Display for Dirac {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for Dirac {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "δ_{}", self.0)
     }
 }

--- a/src/distribution/dirac.rs
+++ b/src/distribution/dirac.rs
@@ -33,6 +33,7 @@ impl core::fmt::Display for DiracError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for DiracError {}
 
 impl Dirac {

--- a/src/distribution/dirichlet.rs
+++ b/src/distribution/dirichlet.rs
@@ -54,6 +54,7 @@ impl core::fmt::Display for DirichletError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for DirichletError {}
 
 impl Dirichlet<Dyn> {

--- a/src/distribution/dirichlet.rs
+++ b/src/distribution/dirichlet.rs
@@ -2,8 +2,8 @@ use crate::distribution::Continuous;
 use crate::function::gamma;
 use crate::prec;
 use crate::statistics::*;
+use core::f64;
 use nalgebra::{Dim, Dyn, OMatrix, OVector};
-use std::f64;
 
 /// Implements the
 /// [Dirichlet](https://en.wikipedia.org/wiki/Dirichlet_distribution)
@@ -41,9 +41,9 @@ pub enum DirichletError {
     AlphaHasInvalidElements,
 }
 
-impl std::fmt::Display for DirichletError {
+impl core::fmt::Display for DirichletError {
     #[cfg_attr(coverage_nightly, coverage(off))]
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             DirichletError::AlphaTooShort => write!(f, "Alpha contains less than two elements"),
             DirichletError::AlphaHasInvalidElements => write!(
@@ -181,12 +181,12 @@ where
     }
 }
 
-impl<D> std::fmt::Display for Dirichlet<D>
+impl<D> core::fmt::Display for Dirichlet<D>
 where
     D: Dim,
     nalgebra::DefaultAllocator: nalgebra::allocator::Allocator<D>,
 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "Dir({}, {})", self.alpha.len(), &self.alpha)
     }
 }

--- a/src/distribution/discrete_uniform.rs
+++ b/src/distribution/discrete_uniform.rs
@@ -38,6 +38,7 @@ impl core::fmt::Display for DiscreteUniformError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for DiscreteUniformError {}
 
 impl DiscreteUniform {

--- a/src/distribution/discrete_uniform.rs
+++ b/src/distribution/discrete_uniform.rs
@@ -29,9 +29,9 @@ pub enum DiscreteUniformError {
     MinMaxInvalid,
 }
 
-impl std::fmt::Display for DiscreteUniformError {
+impl core::fmt::Display for DiscreteUniformError {
     #[cfg_attr(coverage_nightly, coverage(off))]
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             DiscreteUniformError::MinMaxInvalid => write!(f, "Maximum is less than minimum"),
         }
@@ -68,8 +68,8 @@ impl DiscreteUniform {
     }
 }
 
-impl std::fmt::Display for DiscreteUniform {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for DiscreteUniform {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "Uni([{}, {}])", self.min, self.max)
     }
 }

--- a/src/distribution/empirical.rs
+++ b/src/distribution/empirical.rs
@@ -179,12 +179,12 @@ impl Empirical {
     }
 }
 
-impl std::fmt::Display for Empirical {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for Empirical {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let mut enumerated_values = self
             .data
             .iter()
-            .flat_map(|(x, &count)| std::iter::repeat(x.get()).take(count as usize));
+            .flat_map(|(x, &count)| core::iter::repeat(x.get()).take(count as usize));
 
         if let Some(x) = enumerated_values.next() {
             write!(f, "Empirical([{x:.3e}")?;

--- a/src/distribution/erlang.rs
+++ b/src/distribution/erlang.rs
@@ -76,8 +76,8 @@ impl Erlang {
     }
 }
 
-impl std::fmt::Display for Erlang {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for Erlang {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "E({}, {})", self.rate(), self.shape())
     }
 }

--- a/src/distribution/exponential.rs
+++ b/src/distribution/exponential.rs
@@ -1,6 +1,6 @@
 use crate::distribution::{Continuous, ContinuousCDF};
 use crate::statistics::*;
-use std::f64;
+use core::f64;
 
 /// Implements the
 /// [Exp](https://en.wikipedia.org/wiki/Exp_distribution)
@@ -31,9 +31,9 @@ pub enum ExpError {
     RateInvalid,
 }
 
-impl std::fmt::Display for ExpError {
+impl core::fmt::Display for ExpError {
     #[cfg_attr(coverage_nightly, coverage(off))]
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             ExpError::RateInvalid => write!(f, "Rate is NaN, zero or less than zero"),
         }
@@ -84,8 +84,8 @@ impl Exp {
     }
 }
 
-impl std::fmt::Display for Exp {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for Exp {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "Exp({})", self.rate)
     }
 }

--- a/src/distribution/exponential.rs
+++ b/src/distribution/exponential.rs
@@ -40,6 +40,7 @@ impl core::fmt::Display for ExpError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for ExpError {}
 
 impl Exp {

--- a/src/distribution/fisher_snedecor.rs
+++ b/src/distribution/fisher_snedecor.rs
@@ -1,7 +1,7 @@
 use crate::distribution::{Continuous, ContinuousCDF};
 use crate::function::beta;
 use crate::statistics::*;
-use std::f64;
+use core::f64;
 
 /// Implements the
 /// [Fisher-Snedecor](https://en.wikipedia.org/wiki/F-distribution) distribution
@@ -35,9 +35,9 @@ pub enum FisherSnedecorError {
     Freedom2Invalid,
 }
 
-impl std::fmt::Display for FisherSnedecorError {
+impl core::fmt::Display for FisherSnedecorError {
     #[cfg_attr(coverage_nightly, coverage(off))]
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             FisherSnedecorError::Freedom1Invalid => {
                 write!(f, "freedom_1 is NaN, infinite, zero or less than zero.")
@@ -117,8 +117,8 @@ impl FisherSnedecor {
     }
 }
 
-impl std::fmt::Display for FisherSnedecor {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for FisherSnedecor {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "F({},{})", self.freedom_1, self.freedom_2)
     }
 }

--- a/src/distribution/fisher_snedecor.rs
+++ b/src/distribution/fisher_snedecor.rs
@@ -49,6 +49,7 @@ impl core::fmt::Display for FisherSnedecorError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for FisherSnedecorError {}
 
 impl FisherSnedecor {

--- a/src/distribution/gamma.rs
+++ b/src/distribution/gamma.rs
@@ -37,9 +37,9 @@ pub enum GammaError {
     ShapeAndRateInfinite,
 }
 
-impl std::fmt::Display for GammaError {
+impl core::fmt::Display for GammaError {
     #[cfg_attr(coverage_nightly, coverage(off))]
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             GammaError::ShapeInvalid => write!(f, "Shape is NaN zero, or less than zero."),
             GammaError::RateInvalid => write!(f, "Rate is NaN zero, or less than zero."),
@@ -115,8 +115,8 @@ impl Gamma {
     }
 }
 
-impl std::fmt::Display for Gamma {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for Gamma {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "Γ({}, {})", self.shape, self.rate)
     }
 }

--- a/src/distribution/gamma.rs
+++ b/src/distribution/gamma.rs
@@ -48,6 +48,7 @@ impl core::fmt::Display for GammaError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for GammaError {}
 
 impl Gamma {

--- a/src/distribution/geometric.rs
+++ b/src/distribution/geometric.rs
@@ -39,6 +39,7 @@ impl core::fmt::Display for GeometricError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for GeometricError {}
 
 impl Geometric {

--- a/src/distribution/geometric.rs
+++ b/src/distribution/geometric.rs
@@ -1,6 +1,6 @@
 use crate::distribution::{Discrete, DiscreteCDF};
 use crate::statistics::*;
-use std::f64;
+use core::f64;
 
 /// Implements the
 /// [Geometric](https://en.wikipedia.org/wiki/Geometric_distribution)
@@ -30,9 +30,9 @@ pub enum GeometricError {
     ProbabilityInvalid,
 }
 
-impl std::fmt::Display for GeometricError {
+impl core::fmt::Display for GeometricError {
     #[cfg_attr(coverage_nightly, coverage(off))]
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             GeometricError::ProbabilityInvalid => write!(f, "Probability is NaN or not in (0, 1]"),
         }
@@ -84,8 +84,8 @@ impl Geometric {
     }
 }
 
-impl std::fmt::Display for Geometric {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for Geometric {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "Geom({})", self.p)
     }
 }

--- a/src/distribution/gumbel.rs
+++ b/src/distribution/gumbel.rs
@@ -1,7 +1,8 @@
 use super::{Continuous, ContinuousCDF};
 use crate::consts::EULER_MASCHERONI;
 use crate::statistics::*;
-use std::f64::{self, consts::PI};
+use core::f64;
+use core::f64::consts::PI;
 
 /// Implements the [Gumbel](https://en.wikipedia.org/wiki/Gumbel_distribution)
 /// distribution, also known as the type-I generalized extreme value distribution.
@@ -34,9 +35,9 @@ pub enum GumbelError {
     ScaleInvalid,
 }
 
-impl std::fmt::Display for GumbelError {
+impl core::fmt::Display for GumbelError {
     #[cfg_attr(coverage_nightly, coverage(off))]
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             GumbelError::LocationInvalid => write!(f, "Location is NAN"),
             GumbelError::ScaleInvalid => write!(f, "Scale is NAN, zero or less than zero"),
@@ -106,8 +107,8 @@ impl Gumbel {
     }
 }
 
-impl std::fmt::Display for Gumbel {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for Gumbel {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         write!(f, "Gumbel({:?}, {:?})", self.location, self.scale)
     }
 }

--- a/src/distribution/gumbel.rs
+++ b/src/distribution/gumbel.rs
@@ -45,6 +45,7 @@ impl core::fmt::Display for GumbelError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for GumbelError {}
 
 impl Gumbel {

--- a/src/distribution/hypergeometric.rs
+++ b/src/distribution/hypergeometric.rs
@@ -1,8 +1,8 @@
 use crate::distribution::{Discrete, DiscreteCDF};
 use crate::function::factorial;
 use crate::statistics::*;
-use std::cmp;
-use std::f64;
+use core::cmp;
+use core::f64;
 
 /// Implements the
 /// [Hypergeometric](http://en.wikipedia.org/wiki/Hypergeometric_distribution)
@@ -38,9 +38,9 @@ pub enum HypergeometricError {
     TooManyDraws,
 }
 
-impl std::fmt::Display for HypergeometricError {
+impl core::fmt::Display for HypergeometricError {
     #[cfg_attr(coverage_nightly, coverage(off))]
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             HypergeometricError::TooManySuccesses => write!(f, "successes > population"),
             HypergeometricError::TooManyDraws => write!(f, "draws > population"),
@@ -147,8 +147,8 @@ impl Hypergeometric {
     }
 }
 
-impl std::fmt::Display for Hypergeometric {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for Hypergeometric {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(
             f,
             "Hypergeometric({},{},{})",

--- a/src/distribution/hypergeometric.rs
+++ b/src/distribution/hypergeometric.rs
@@ -48,6 +48,7 @@ impl core::fmt::Display for HypergeometricError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for HypergeometricError {}
 
 impl Hypergeometric {

--- a/src/distribution/internal.rs
+++ b/src/distribution/internal.rs
@@ -40,12 +40,12 @@ pub fn integral_bisection_search<K: Num + Clone, T: Num + PartialOrd>(
 #[macro_use]
 #[cfg(test)]
 pub mod test {
-    use super::*;
     use crate::distribution::{Continuous, ContinuousCDF, Discrete, DiscreteCDF};
 
     #[macro_export]
     macro_rules! testing_boiler {
         ($($arg_name:ident: $arg_ty:ty),+; $dist:ty; $dist_err:ty) => {
+            #[cfg(feature = "std")]
             fn make_param_text($($arg_name: $arg_ty),+) -> String {
                 // ""
                 let mut param_text = String::new();
@@ -66,6 +66,12 @@ pub mod test {
                 param_text.pop();
 
                 param_text
+            }
+
+            #[cfg(not(feature = "std"))]
+            #[allow(unused)]
+            fn make_param_text($($arg_name: $arg_ty),+) -> &'static str {
+                "(params N/A)"
             }
 
             /// Creates and returns a distribution with the given parameters,
@@ -453,7 +459,10 @@ pub mod test {
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn test_integer_bisection() {
+        use super::*;
+
         fn search(z: usize, data: &[usize]) -> Option<usize> {
             integral_bisection_search(|idx: &usize| data[*idx], z, 0, data.len() - 1)
         }

--- a/src/distribution/internal.rs
+++ b/src/distribution/internal.rs
@@ -372,10 +372,11 @@ pub mod test {
 
             let cdf = dist.cdf(x);
             if (sum - cdf).abs() > 1e-3 {
-                println!("Integral of pdf doesn't equal cdf!");
-                println!("Integration from {x_min} by {step} to {x} = {sum}");
-                println!("cdf = {cdf}");
-                panic!();
+                panic!(
+                    "Integral of pdf doesn't equal cdf!\n\
+                        Integration from {x_min} by {step} to {x} = {sum}\n\
+                        cdf = {cdf}"
+                );
             }
 
             if x >= x_max {

--- a/src/distribution/inverse_gamma.rs
+++ b/src/distribution/inverse_gamma.rs
@@ -49,6 +49,7 @@ impl core::fmt::Display for InverseGammaError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for InverseGammaError {}
 
 impl InverseGamma {

--- a/src/distribution/inverse_gamma.rs
+++ b/src/distribution/inverse_gamma.rs
@@ -1,7 +1,7 @@
 use crate::distribution::{Continuous, ContinuousCDF};
 use crate::function::gamma;
 use crate::statistics::*;
-use std::f64;
+use core::f64;
 
 /// Implements the [Inverse
 /// Gamma](https://en.wikipedia.org/wiki/Inverse-gamma_distribution)
@@ -35,9 +35,9 @@ pub enum InverseGammaError {
     RateInvalid,
 }
 
-impl std::fmt::Display for InverseGammaError {
+impl core::fmt::Display for InverseGammaError {
     #[cfg_attr(coverage_nightly, coverage(off))]
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             InverseGammaError::ShapeInvalid => {
                 write!(f, "Shape is NaN, infinite, zero or less than zero")
@@ -112,8 +112,8 @@ impl InverseGamma {
     }
 }
 
-impl std::fmt::Display for InverseGamma {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for InverseGamma {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "Inv-Gamma({}, {})", self.shape, self.rate)
     }
 }

--- a/src/distribution/laplace.rs
+++ b/src/distribution/laplace.rs
@@ -1,6 +1,6 @@
 use crate::distribution::{Continuous, ContinuousCDF};
 use crate::statistics::{Distribution, Max, Median, Min, Mode};
-use std::f64;
+use core::f64;
 
 /// Implements the [Laplace](https://en.wikipedia.org/wiki/Laplace_distribution)
 /// distribution.
@@ -32,9 +32,9 @@ pub enum LaplaceError {
     ScaleInvalid,
 }
 
-impl std::fmt::Display for LaplaceError {
+impl core::fmt::Display for LaplaceError {
     #[cfg_attr(coverage_nightly, coverage(off))]
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             LaplaceError::LocationInvalid => write!(f, "Location is NaN"),
             LaplaceError::ScaleInvalid => write!(f, "Scale is NaN, zero or less than zero"),
@@ -104,8 +104,8 @@ impl Laplace {
     }
 }
 
-impl std::fmt::Display for Laplace {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for Laplace {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "Laplace({}, {})", self.location, self.scale)
     }
 }

--- a/src/distribution/laplace.rs
+++ b/src/distribution/laplace.rs
@@ -42,6 +42,7 @@ impl core::fmt::Display for LaplaceError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for LaplaceError {}
 
 impl Laplace {

--- a/src/distribution/log_normal.rs
+++ b/src/distribution/log_normal.rs
@@ -2,7 +2,7 @@ use crate::consts;
 use crate::distribution::{Continuous, ContinuousCDF};
 use crate::function::erf;
 use crate::statistics::*;
-use std::f64;
+use core::f64;
 
 /// Implements the
 /// [Log-normal](https://en.wikipedia.org/wiki/Log-normal_distribution)
@@ -36,9 +36,9 @@ pub enum LogNormalError {
     ScaleInvalid,
 }
 
-impl std::fmt::Display for LogNormalError {
+impl core::fmt::Display for LogNormalError {
     #[cfg_attr(coverage_nightly, coverage(off))]
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             LogNormalError::LocationInvalid => write!(f, "Location is NaN"),
             LogNormalError::ScaleInvalid => write!(f, "Scale is NaN, zero or less than zero"),
@@ -81,8 +81,8 @@ impl LogNormal {
     }
 }
 
-impl std::fmt::Display for LogNormal {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for LogNormal {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "LogNormal({}, {}^2)", self.location, self.scale)
     }
 }

--- a/src/distribution/log_normal.rs
+++ b/src/distribution/log_normal.rs
@@ -46,6 +46,7 @@ impl core::fmt::Display for LogNormalError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for LogNormalError {}
 
 impl LogNormal {

--- a/src/distribution/mod.rs
+++ b/src/distribution/mod.rs
@@ -8,6 +8,7 @@ use num_traits::NumAssignOps;
 pub use self::bernoulli::Bernoulli;
 pub use self::beta::{Beta, BetaError};
 pub use self::binomial::{Binomial, BinomialError};
+#[cfg(feature = "std")]
 pub use self::categorical::{Categorical, CategoricalError};
 pub use self::cauchy::{Cauchy, CauchyError};
 pub use self::chi::{Chi, ChiError};
@@ -16,6 +17,7 @@ pub use self::dirac::{Dirac, DiracError};
 #[cfg(feature = "nalgebra")]
 pub use self::dirichlet::{Dirichlet, DirichletError};
 pub use self::discrete_uniform::{DiscreteUniform, DiscreteUniformError};
+#[cfg(feature = "std")]
 pub use self::empirical::Empirical;
 pub use self::erlang::Erlang;
 pub use self::exponential::{Exp, ExpError};
@@ -45,6 +47,7 @@ pub use self::weibull::{Weibull, WeibullError};
 mod bernoulli;
 mod beta;
 mod binomial;
+#[cfg(feature = "std")]
 mod categorical;
 mod cauchy;
 mod chi;
@@ -54,6 +57,7 @@ mod dirac;
 #[cfg_attr(docsrs, doc(cfg(feature = "nalgebra")))]
 mod dirichlet;
 mod discrete_uniform;
+#[cfg(feature = "std")]
 mod empirical;
 mod erlang;
 mod exponential;

--- a/src/distribution/multinomial.rs
+++ b/src/distribution/multinomial.rs
@@ -45,9 +45,9 @@ pub enum MultinomialError {
     ProbabilityInvalid,
 }
 
-impl std::fmt::Display for MultinomialError {
+impl core::fmt::Display for MultinomialError {
     #[cfg_attr(coverage_nightly, coverage(off))]
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             MultinomialError::NotEnoughProbabilities => write!(f, "Fewer than two probabilities"),
             MultinomialError::ProbabilitySumZero => write!(f, "The probabilities sum up to zero"),
@@ -149,12 +149,12 @@ where
     }
 }
 
-impl<D> std::fmt::Display for Multinomial<D>
+impl<D> core::fmt::Display for Multinomial<D>
 where
     D: Dim,
     nalgebra::DefaultAllocator: nalgebra::allocator::Allocator<D>,
 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "Multinom({:#?},{})", self.p, self.n)
     }
 }
@@ -363,7 +363,7 @@ mod tests {
         statistics::{MeanN, VarianceN},
     };
     use nalgebra::{dmatrix, dvector, vector, DimMin, Dyn, OVector};
-    use std::fmt::{Debug, Display};
+    use core::fmt::{Debug, Display};
 
     fn try_create<D>(p: OVector<f64, D>, n: u64) -> Multinomial<D>
     where

--- a/src/distribution/multinomial.rs
+++ b/src/distribution/multinomial.rs
@@ -59,6 +59,7 @@ impl core::fmt::Display for MultinomialError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for MultinomialError {}
 
 impl Multinomial<Dyn> {

--- a/src/distribution/multivariate_normal.rs
+++ b/src/distribution/multivariate_normal.rs
@@ -1,8 +1,8 @@
 use crate::distribution::Continuous;
 use crate::statistics::{Max, MeanN, Min, Mode, VarianceN};
+use core::f64;
+use core::f64::consts::{E, PI};
 use nalgebra::{Cholesky, Const, DMatrix, DVector, Dim, DimMin, Dyn, OMatrix, OVector};
-use std::f64;
-use std::f64::consts::{E, PI};
 
 /// Computes both the normalization and exponential argument in the normal
 /// distribution, returning `None` on dimension mismatch.
@@ -116,9 +116,9 @@ pub enum MultivariateNormalError {
     CholeskyFailed,
 }
 
-impl std::fmt::Display for MultivariateNormalError {
+impl core::fmt::Display for MultivariateNormalError {
     #[cfg_attr(coverage_nightly, coverage(off))]
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             MultivariateNormalError::CovInvalid => {
                 write!(f, "Covariance matrix is asymmetric or contains a NaN")
@@ -226,13 +226,13 @@ where
     }
 }
 
-impl<D> std::fmt::Display for MultivariateNormal<D>
+impl<D> core::fmt::Display for MultivariateNormal<D>
 where
     D: Dim,
     nalgebra::DefaultAllocator:
         nalgebra::allocator::Allocator<D> + nalgebra::allocator::Allocator<D, D>,
 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "N({}, {})", &self.mu, &self.cov)
     }
 }

--- a/src/distribution/multivariate_normal.rs
+++ b/src/distribution/multivariate_normal.rs
@@ -135,6 +135,7 @@ impl core::fmt::Display for MultivariateNormalError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for MultivariateNormalError {}
 
 impl MultivariateNormal<Dyn> {

--- a/src/distribution/multivariate_students_t.rs
+++ b/src/distribution/multivariate_students_t.rs
@@ -1,8 +1,8 @@
 use crate::distribution::Continuous;
 use crate::function::gamma;
 use crate::statistics::{Max, MeanN, Min, Mode, VarianceN};
+use core::f64::consts::PI;
 use nalgebra::{Cholesky, Const, DMatrix, Dim, DimMin, Dyn, OMatrix, OVector};
-use std::f64::consts::PI;
 
 /// Implements the [Multivariate Student's t-distribution](https://en.wikipedia.org/wiki/Multivariate_t-distribution)
 /// distribution using the "nalgebra" crate for matrix operations.
@@ -58,9 +58,9 @@ pub enum MultivariateStudentError {
     CholeskyFailed,
 }
 
-impl std::fmt::Display for MultivariateStudentError {
+impl core::fmt::Display for MultivariateStudentError {
     #[cfg_attr(coverage_nightly, coverage(off))]
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             MultivariateStudentError::ScaleInvalid => {
                 write!(f, "Scale matrix is asymmetric or contains a NaN")
@@ -605,7 +605,7 @@ mod tests  {
         let mvs = MultivariateStudent::new(vec![1., 1.], vec![1., 0., 0., 1.], 2.)
             .expect("hard coded valid construction");
         assert_eq!(mvs.freedom(), 2.);
-        assert_relative_eq!(mvs.ln_pdf_const(), std::f64::consts::TAU.recip().ln(), epsilon = 1e-15);
+        assert_relative_eq!(mvs.ln_pdf_const(), core::f64::consts::TAU.recip().ln(), epsilon = 1e-15);
 
         // compare to static
         assert_eq!(mvs.dim(), 2); 

--- a/src/distribution/multivariate_students_t.rs
+++ b/src/distribution/multivariate_students_t.rs
@@ -82,6 +82,7 @@ impl core::fmt::Display for MultivariateStudentError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for MultivariateStudentError {}
 
 impl MultivariateStudent<Dyn> {

--- a/src/distribution/negative_binomial.rs
+++ b/src/distribution/negative_binomial.rs
@@ -1,7 +1,7 @@
 use crate::distribution::{Discrete, DiscreteCDF};
 use crate::function::{beta, gamma};
 use crate::statistics::*;
-use std::f64;
+use core::f64;
 
 /// Implements the
 /// [negative binomial](http://en.wikipedia.org/wiki/Negative_binomial_distribution)
@@ -50,9 +50,9 @@ pub enum NegativeBinomialError {
     PInvalid,
 }
 
-impl std::fmt::Display for NegativeBinomialError {
+impl core::fmt::Display for NegativeBinomialError {
     #[cfg_attr(coverage_nightly, coverage(off))]
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             NegativeBinomialError::RInvalid => write!(f, "r is NaN or less than zero"),
             NegativeBinomialError::PInvalid => write!(f, "p is NaN or not in [0, 1]"),
@@ -129,8 +129,8 @@ impl NegativeBinomial {
     }
 }
 
-impl std::fmt::Display for NegativeBinomial {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for NegativeBinomial {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "NB({},{})", self.r, self.p)
     }
 }

--- a/src/distribution/negative_binomial.rs
+++ b/src/distribution/negative_binomial.rs
@@ -60,6 +60,7 @@ impl core::fmt::Display for NegativeBinomialError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for NegativeBinomialError {}
 
 impl NegativeBinomial {

--- a/src/distribution/normal.rs
+++ b/src/distribution/normal.rs
@@ -46,6 +46,7 @@ impl core::fmt::Display for NormalError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for NormalError {}
 
 impl Normal {

--- a/src/distribution/normal.rs
+++ b/src/distribution/normal.rs
@@ -2,7 +2,7 @@ use crate::consts;
 use crate::distribution::{Continuous, ContinuousCDF};
 use crate::function::erf;
 use crate::statistics::*;
-use std::f64;
+use core::f64;
 
 /// Implements the [Normal](https://en.wikipedia.org/wiki/Normal_distribution)
 /// distribution
@@ -34,9 +34,9 @@ pub enum NormalError {
     StandardDeviationInvalid,
 }
 
-impl std::fmt::Display for NormalError {
+impl core::fmt::Display for NormalError {
     #[cfg_attr(coverage_nightly, coverage(off))]
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             NormalError::MeanInvalid => write!(f, "Mean is NaN"),
             NormalError::StandardDeviationInvalid => {
@@ -99,8 +99,8 @@ impl Normal {
     }
 }
 
-impl std::fmt::Display for Normal {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for Normal {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "N({},{})", self.mean, self.std_dev)
     }
 }
@@ -357,7 +357,7 @@ pub fn sample_unchecked<R: ::rand::Rng + ?Sized>(rng: &mut R, mean: f64, std_dev
     mean + std_dev * ziggurat::sample_std_normal(rng)
 }
 
-impl std::default::Default for Normal {
+impl core::default::Default for Normal {
     /// Returns the standard normal distribution with a mean of 0
     /// and a standard deviation of 1.
     fn default() -> Self {

--- a/src/distribution/pareto.rs
+++ b/src/distribution/pareto.rs
@@ -43,6 +43,7 @@ impl core::fmt::Display for ParetoError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for ParetoError {}
 
 impl Pareto {

--- a/src/distribution/pareto.rs
+++ b/src/distribution/pareto.rs
@@ -1,6 +1,6 @@
 use crate::distribution::{Continuous, ContinuousCDF};
 use crate::statistics::*;
-use std::f64;
+use core::f64;
 
 /// Implements the [Pareto](https://en.wikipedia.org/wiki/Pareto_distribution)
 /// distribution
@@ -33,9 +33,9 @@ pub enum ParetoError {
     ShapeInvalid,
 }
 
-impl std::fmt::Display for ParetoError {
+impl core::fmt::Display for ParetoError {
     #[cfg_attr(coverage_nightly, coverage(off))]
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             ParetoError::ScaleInvalid => write!(f, "Scale is NaN, zero, or less than zero"),
             ParetoError::ShapeInvalid => write!(f, "Shape is NaN, zero, or less than zero"),
@@ -106,8 +106,8 @@ impl Pareto {
     }
 }
 
-impl std::fmt::Display for Pareto {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for Pareto {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "Pareto({},{})", self.scale, self.shape)
     }
 }

--- a/src/distribution/poisson.rs
+++ b/src/distribution/poisson.rs
@@ -39,6 +39,7 @@ impl core::fmt::Display for PoissonError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for PoissonError {}
 
 impl Poisson {

--- a/src/distribution/poisson.rs
+++ b/src/distribution/poisson.rs
@@ -1,7 +1,7 @@
 use crate::distribution::{Discrete, DiscreteCDF};
 use crate::function::{factorial, gamma};
 use crate::statistics::*;
-use std::f64;
+use core::f64;
 
 /// Implements the [Poisson](https://en.wikipedia.org/wiki/Poisson_distribution)
 /// distribution
@@ -30,9 +30,9 @@ pub enum PoissonError {
     LambdaInvalid,
 }
 
-impl std::fmt::Display for PoissonError {
+impl core::fmt::Display for PoissonError {
     #[cfg_attr(coverage_nightly, coverage(off))]
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             PoissonError::LambdaInvalid => write!(f, "Lambda is NaN, zero or less than zero"),
         }
@@ -83,8 +83,8 @@ impl Poisson {
     }
 }
 
-impl std::fmt::Display for Poisson {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for Poisson {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "Pois({})", self.lambda)
     }
 }

--- a/src/distribution/students_t.rs
+++ b/src/distribution/students_t.rs
@@ -51,6 +51,7 @@ impl core::fmt::Display for StudentsTError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for StudentsTError {}
 
 impl StudentsT {

--- a/src/distribution/students_t.rs
+++ b/src/distribution/students_t.rs
@@ -1,7 +1,7 @@
 use crate::distribution::{Continuous, ContinuousCDF};
 use crate::function::{beta, gamma};
 use crate::statistics::*;
-use std::f64;
+use core::f64;
 
 /// Implements the [Student's
 /// T](https://en.wikipedia.org/wiki/Student%27s_t-distribution) distribution
@@ -38,9 +38,9 @@ pub enum StudentsTError {
     FreedomInvalid,
 }
 
-impl std::fmt::Display for StudentsTError {
+impl core::fmt::Display for StudentsTError {
     #[cfg_attr(coverage_nightly, coverage(off))]
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             StudentsTError::LocationInvalid => write!(f, "Location is NaN"),
             StudentsTError::ScaleInvalid => write!(f, "Scale is NaN, zero or less than zero"),
@@ -136,8 +136,8 @@ impl StudentsT {
     }
 }
 
-impl std::fmt::Display for StudentsT {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for StudentsT {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "t_{}({},{})", self.freedom, self.location, self.scale)
     }
 }
@@ -586,7 +586,7 @@ mod tests {
     #[test]
     fn test_pdf() {
         let pdf = |arg: f64| move |x: StudentsT| x.pdf(arg);
-        test_relative(0.0, 1.0, 1.0, std::f64::consts::FRAC_1_PI, pdf(0.0));
+        test_relative(0.0, 1.0, 1.0, core::f64::consts::FRAC_1_PI, pdf(0.0));
         test_relative(0.0, 1.0, 1.0, 0.159154943091895, pdf(1.0));
         test_relative(0.0, 1.0, 1.0, 0.159154943091895, pdf(-1.0));
         test_relative(0.0, 1.0, 1.0, 0.063661977236758, pdf(2.0));

--- a/src/distribution/triangular.rs
+++ b/src/distribution/triangular.rs
@@ -58,6 +58,7 @@ impl core::fmt::Display for TriangularError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for TriangularError {}
 
 impl Triangular {

--- a/src/distribution/triangular.rs
+++ b/src/distribution/triangular.rs
@@ -1,6 +1,6 @@
 use crate::distribution::{Continuous, ContinuousCDF};
 use crate::statistics::*;
-use std::f64;
+use core::f64;
 
 /// Implements the
 /// [Triangular](https://en.wikipedia.org/wiki/Triangular_distribution)
@@ -43,9 +43,9 @@ pub enum TriangularError {
     MinEqualsMax,
 }
 
-impl std::fmt::Display for TriangularError {
+impl core::fmt::Display for TriangularError {
     #[cfg_attr(coverage_nightly, coverage(off))]
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             TriangularError::MinInvalid => write!(f, "Minimum is NaN or infinite."),
             TriangularError::MaxInvalid => write!(f, "Maximum is NaN or infinite."),
@@ -105,8 +105,8 @@ impl Triangular {
     }
 }
 
-impl std::fmt::Display for Triangular {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for Triangular {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "Triangular([{},{}], {})", self.min, self.max, self.mode)
     }
 }

--- a/src/distribution/uniform.rs
+++ b/src/distribution/uniform.rs
@@ -49,6 +49,7 @@ impl core::fmt::Display for UniformError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for UniformError {}
 
 impl Uniform {

--- a/src/distribution/uniform.rs
+++ b/src/distribution/uniform.rs
@@ -1,7 +1,6 @@
 use crate::distribution::{Continuous, ContinuousCDF};
 use crate::statistics::*;
-use std::f64;
-use std::fmt::Debug;
+use core::f64;
 
 /// Implements the [Continuous
 /// Uniform](https://en.wikipedia.org/wiki/Uniform_distribution_(continuous))
@@ -37,9 +36,9 @@ pub enum UniformError {
     MaxNotGreaterThanMin,
 }
 
-impl std::fmt::Display for UniformError {
+impl core::fmt::Display for UniformError {
     #[cfg_attr(coverage_nightly, coverage(off))]
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             UniformError::MinInvalid => write!(f, "Minimum is NaN or infinite"),
             UniformError::MaxInvalid => write!(f, "Maximum is NaN or infinite"),
@@ -65,7 +64,7 @@ impl Uniform {
     ///
     /// ```
     /// use statrs::distribution::Uniform;
-    /// use std::f64;
+    /// use core::f64;
     ///
     /// let mut result = Uniform::new(0.0, 1.0);
     /// assert!(result.is_ok());
@@ -113,8 +112,8 @@ impl Default for Uniform {
     }
 }
 
-impl std::fmt::Display for Uniform {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for Uniform {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "Uni([{},{}])", self.min, self.max)
     }
 }

--- a/src/distribution/weibull.rs
+++ b/src/distribution/weibull.rs
@@ -2,7 +2,7 @@ use crate::consts;
 use crate::distribution::{Continuous, ContinuousCDF};
 use crate::function::gamma;
 use crate::statistics::*;
-use std::f64;
+use core::f64;
 
 /// Implements the [Weibull](https://en.wikipedia.org/wiki/Weibull_distribution)
 /// distribution
@@ -37,9 +37,9 @@ pub enum WeibullError {
     ScaleInvalid,
 }
 
-impl std::fmt::Display for WeibullError {
+impl core::fmt::Display for WeibullError {
     #[cfg_attr(coverage_nightly, coverage(off))]
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             WeibullError::ShapeInvalid => write!(f, "Shape is NaN, zero or less than zero."),
             WeibullError::ScaleInvalid => write!(f, "Scale is NaN, zero or less than zero."),
@@ -114,8 +114,8 @@ impl Weibull {
     }
 }
 
-impl std::fmt::Display for Weibull {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for Weibull {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "Weibull({},{})", self.scale, self.shape)
     }
 }

--- a/src/distribution/weibull.rs
+++ b/src/distribution/weibull.rs
@@ -47,6 +47,7 @@ impl core::fmt::Display for WeibullError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for WeibullError {}
 
 impl Weibull {

--- a/src/function/beta.rs
+++ b/src/function/beta.rs
@@ -30,6 +30,7 @@ impl core::fmt::Display for BetaFuncError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for BetaFuncError {}
 
 /// Computes the natural logarithm

--- a/src/function/beta.rs
+++ b/src/function/beta.rs
@@ -3,7 +3,7 @@
 
 use crate::function::gamma;
 use crate::prec;
-use std::f64;
+use core::f64;
 
 /// Represents the errors that can occur when computing the natural logarithm
 /// of the beta function or the regularized lower incomplete beta function.
@@ -20,8 +20,8 @@ pub enum BetaFuncError {
     XOutOfRange,
 }
 
-impl std::fmt::Display for BetaFuncError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl core::fmt::Display for BetaFuncError {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             BetaFuncError::ANotGreaterThanZero => write!(f, "a is zero or less than zero"),
             BetaFuncError::BNotGreaterThanZero => write!(f, "b is zero or less than zero"),

--- a/src/function/erf.rs
+++ b/src/function/erf.rs
@@ -2,7 +2,7 @@
 //! related functions
 
 use crate::function::evaluate;
-use std::f64;
+use core::f64;
 
 /// `erf` calculates the error function at `x`.
 pub fn erf(x: f64) -> f64 {
@@ -738,7 +738,7 @@ fn erf_inv_impl(p: f64, q: f64, s: f64) -> f64 {
 #[rustfmt::skip]
 #[cfg(test)]
 mod tests {
-    use std::f64;
+    use core::f64;
 
     #[test]
     fn test_erf() {

--- a/src/function/evaluate.rs
+++ b/src/function/evaluate.rs
@@ -26,7 +26,7 @@ pub fn polynomial(z: f64, coeff: &[f64]) -> f64 {
 #[rustfmt::skip]
 #[cfg(test)]
 mod tests {
-    use std::f64;
+    use core::f64;
 
     // these tests probably could be more robust
     #[test]

--- a/src/function/gamma.rs
+++ b/src/function/gamma.rs
@@ -26,6 +26,7 @@ impl core::fmt::Display for GammaFuncError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for GammaFuncError {}
 
 /// Auxiliary variable when evaluating the `gamma_ln` function

--- a/src/function/gamma.rs
+++ b/src/function/gamma.rs
@@ -3,7 +3,7 @@
 
 use crate::consts;
 use crate::prec;
-use std::f64;
+use core::f64;
 
 /// Represents the errors that can occur when computing any of the incomplete
 /// gamma functions.
@@ -17,8 +17,8 @@ pub enum GammaFuncError {
     XInvalid,
 }
 
-impl std::fmt::Display for GammaFuncError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl core::fmt::Display for GammaFuncError {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             GammaFuncError::AInvalid => write!(f, "a is infinite, zero or less than zero"),
             GammaFuncError::XInvalid => write!(f, "x is infinite, zero or less than zero"),
@@ -446,7 +446,7 @@ fn signum(x: f64) -> f64 {
 mod tests {
     use super::*;
 
-    use std::f64::consts;
+    use core::f64::consts;
 
     #[test]
     fn test_gamma() {

--- a/src/function/harmonic.rs
+++ b/src/function/harmonic.rs
@@ -33,7 +33,7 @@ pub fn gen_harmonic(n: u64, m: f64) -> f64 {
 #[rustfmt::skip]
 #[cfg(test)]
 mod tests {
-    use std::f64;
+    use core::f64;
 
     #[test]
     fn test_harmonic() {

--- a/src/function/logistic.rs
+++ b/src/function/logistic.rs
@@ -27,7 +27,7 @@ pub fn checked_logit(p: f64) -> Option<f64> {
 #[rustfmt::skip]
 #[cfg(test)]
 mod tests {
-    use std::f64;
+    use core::f64;
 
     #[test]
     fn test_logistic() {

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -1,7 +1,7 @@
 //! Provides utility functions for generating data sequences
 
 use crate::euclid::Modulus;
-use std::f64::consts;
+use core::f64::consts;
 /// Generates a base 10 log spaced vector of the given length between the
 /// specified decade exponents (inclusive). Equivalent to MATLAB logspace
 ///
@@ -81,8 +81,8 @@ impl InfinitePeriodic {
     }
 }
 
-impl std::fmt::Display for InfinitePeriodic {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for InfinitePeriodic {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{self:#?}")
     }
 }
@@ -167,8 +167,8 @@ impl InfiniteSinusoidal {
     }
 }
 
-impl std::fmt::Display for InfiniteSinusoidal {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for InfiniteSinusoidal {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{:#?}", &self)
     }
 }
@@ -227,8 +227,8 @@ impl InfiniteSquare {
     }
 }
 
-impl std::fmt::Display for InfiniteSquare {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for InfiniteSquare {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{:#?}", &self)
     }
 }
@@ -300,8 +300,8 @@ impl InfiniteTriangle {
     }
 }
 
-impl std::fmt::Display for InfiniteTriangle {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for InfiniteTriangle {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{:#?}", &self)
     }
 }
@@ -357,8 +357,8 @@ impl InfiniteSawtooth {
     }
 }
 
-impl std::fmt::Display for InfiniteSawtooth {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for InfiniteSawtooth {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{:#?}", &self)
     }
 }

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -13,6 +13,7 @@ use core::f64::consts;
 /// let x = generate::log_spaced(5, 0.0, 4.0);
 /// assert_eq!(x, [1.0, 10.0, 100.0, 1000.0, 10000.0]);
 /// ```
+#[cfg(feature = "std")]
 pub fn log_spaced(length: usize, start_exp: f64, stop_exp: f64) -> Vec<f64> {
     match length {
         0 => Vec::new(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@
 #![forbid(unsafe_code)]
 #![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 #[macro_use]
 extern crate approx;

--- a/src/statistics/iter_statistics.rs
+++ b/src/statistics/iter_statistics.rs
@@ -1,6 +1,6 @@
 use crate::statistics::*;
-use std::borrow::Borrow;
-use std::f64;
+use core::borrow::Borrow;
+use core::f64;
 
 impl<T> Statistics<f64> for T
 where
@@ -242,7 +242,7 @@ where
 #[rustfmt::skip]
 #[cfg(test)]
 mod tests {
-    use std::f64::consts;
+    use core::f64::consts;
     use crate::statistics::Statistics;
     use crate::generate::{InfinitePeriodic, InfiniteSinusoidal};
 

--- a/src/statistics/iter_statistics.rs
+++ b/src/statistics/iter_statistics.rs
@@ -261,17 +261,24 @@ mod tests {
 
     #[test]
     fn test_large_samples() {
-        let shorter = InfinitePeriodic::default(4.0, 1.0).take(4*4096).collect::<Vec<f64>>();
-        let longer = InfinitePeriodic::default(4.0, 1.0).take(4*32768).collect::<Vec<f64>>();
-        assert_almost_eq!((&shorter).mean(), 0.375, 1e-14);
-        assert_almost_eq!((&longer).mean(), 0.375, 1e-14);
-        assert_almost_eq!((&shorter).quadratic_mean(), (0.21875f64).sqrt(), 1e-14);
-        assert_almost_eq!((&longer).quadratic_mean(), (0.21875f64).sqrt(), 1e-14);
+        let shorter = || InfinitePeriodic::default(4.0, 1.0).take(4*4096);
+        let longer = || InfinitePeriodic::default(4.0, 1.0).take(4*32768);
+        let s_mean = shorter().mean();
+        let s_qmean = shorter().quadratic_mean();
+        let l_mean = longer().mean();
+        let l_qmean = longer().quadratic_mean();
+
+        assert_almost_eq!(s_mean, 0.375, 1e-14);
+        assert_almost_eq!(l_mean, 0.375, 1e-14);
+        assert_almost_eq!(s_qmean, (0.21875f64).sqrt(), 1e-14);
+        assert_almost_eq!(l_qmean, (0.21875f64).sqrt(), 1e-14);
     }
 
     #[test]
     fn test_quadratic_mean_of_sinusoidal() {
-        let data = InfiniteSinusoidal::default(64.0, 16.0, 2.0).take(128).collect::<Vec<f64>>();
-        assert_almost_eq!((&data).quadratic_mean(), 2.0 / consts::SQRT_2, 1e-15);
+        let data = InfiniteSinusoidal::default(64.0, 16.0, 2.0).take(128);
+        let qmean = data.quadratic_mean();
+
+        assert_almost_eq!(qmean, 2.0 / consts::SQRT_2, 1e-15);
     }
 }

--- a/src/statistics/order_statistics.rs
+++ b/src/statistics/order_statistics.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "std")]
 use super::RankTieBreaker;
 
 /// The `OrderStatistics` trait provides statistical utilities
@@ -215,5 +216,6 @@ pub trait OrderStatistics<T> {
     /// assert_eq!(y.clone().ranks(RankTieBreaker::Min), [1.0, 4.0, 2.0,
     /// 2.0]);
     /// ```
+    #[cfg(feature = "std")]
     fn ranks(&mut self, tie_breaker: RankTieBreaker) -> Vec<T>;
 }

--- a/src/statistics/slice_statistics.rs
+++ b/src/statistics/slice_statistics.rs
@@ -4,12 +4,12 @@ use core::ops::{Index, IndexMut};
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub struct Data<D>(D);
 
-impl<D, I> std::fmt::Display for Data<D>
+impl<D, I> core::fmt::Display for Data<D>
 where
     D: Clone + IntoIterator<Item = I>,
-    I: Clone + std::fmt::Display,
+    I: Clone + core::fmt::Display,
 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let mut tee = self.0.clone().into_iter();
         write!(f, "Data([")?;
 

--- a/src/statistics/slice_statistics.rs
+++ b/src/statistics/slice_statistics.rs
@@ -197,6 +197,7 @@ impl<D: AsMut<[f64]> + AsRef<[f64]>> OrderStatistics<f64> for Data<D> {
         self.upper_quartile() - self.lower_quartile()
     }
 
+    #[cfg(feature = "std")]
     fn ranks(&mut self, tie_breaker: RankTieBreaker) -> Vec<f64> {
         let n = self.len();
         let mut ranks: Vec<f64> = vec![0.0; n];
@@ -392,6 +393,7 @@ impl<D: AsMut<[f64]> + AsRef<[f64]> + Clone> Median<f64> for Data<D> {
     }
 }
 
+#[cfg(feature = "std")]
 fn handle_rank_ties(
     ranks: &mut [f64],
     index: &[(usize, &f64)],
@@ -446,6 +448,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn test_ranks() {
         let sorted_distinct = [1.0, 2.0, 4.0, 7.0, 8.0, 9.0, 10.0, 12.0];
         let mut sorted_distinct = Data::new(sorted_distinct);
@@ -534,6 +537,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn test_median_long_constant_seq() {
         let even = vec![2.0; 100000];
         let even = Data::new(even);

--- a/src/statistics/statistics.rs
+++ b/src/statistics/statistics.rs
@@ -25,7 +25,7 @@ pub trait Statistics<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::f64;
+    /// use core::f64;
     /// use statrs::statistics::Statistics;
     ///
     /// let x = &[];
@@ -48,7 +48,7 @@ pub trait Statistics<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::f64;
+    /// use core::f64;
     /// use statrs::statistics::Statistics;
     ///
     /// let x = &[];
@@ -71,7 +71,7 @@ pub trait Statistics<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::f64;
+    /// use core::f64;
     /// use statrs::statistics::Statistics;
     ///
     /// let x = &[];
@@ -94,7 +94,7 @@ pub trait Statistics<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::f64;
+    /// use core::f64;
     /// use statrs::statistics::Statistics;
     ///
     /// let x = &[];
@@ -121,7 +121,7 @@ pub trait Statistics<T> {
     /// #[macro_use]
     /// extern crate statrs;
     ///
-    /// use std::f64;
+    /// use core::f64;
     /// use statrs::statistics::Statistics;
     ///
     /// # fn main() {
@@ -151,7 +151,7 @@ pub trait Statistics<T> {
     /// #[macro_use]
     /// extern crate statrs;
     ///
-    /// use std::f64;
+    /// use core::f64;
     /// use statrs::statistics::Statistics;
     ///
     /// # fn main() {
@@ -190,7 +190,7 @@ pub trait Statistics<T> {
     /// #[macro_use]
     /// extern crate statrs;
     ///
-    /// use std::f64;
+    /// use core::f64;
     /// use statrs::statistics::Statistics;
     ///
     /// # fn main() {
@@ -226,7 +226,7 @@ pub trait Statistics<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::f64;
+    /// use core::f64;
     /// use statrs::statistics::Statistics;
     ///
     /// let x = &[];
@@ -254,7 +254,7 @@ pub trait Statistics<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::f64;
+    /// use core::f64;
     /// use statrs::statistics::Statistics;
     ///
     /// let x = &[];
@@ -280,7 +280,7 @@ pub trait Statistics<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::f64;
+    /// use core::f64;
     /// use statrs::statistics::Statistics;
     ///
     /// let x = &[];
@@ -306,7 +306,7 @@ pub trait Statistics<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::f64;
+    /// use core::f64;
     /// use statrs::statistics::Statistics;
     ///
     /// let x = &[];
@@ -341,7 +341,7 @@ pub trait Statistics<T> {
     /// #[macro_use]
     /// extern crate statrs;
     ///
-    /// use std::f64;
+    /// use core::f64;
     /// use statrs::statistics::Statistics;
     ///
     /// # fn main() {
@@ -378,7 +378,7 @@ pub trait Statistics<T> {
     /// #[macro_use]
     /// extern crate statrs;
     ///
-    /// use std::f64;
+    /// use core::f64;
     /// use statrs::statistics::Statistics;
     ///
     /// # fn main() {
@@ -408,7 +408,7 @@ pub trait Statistics<T> {
     /// #[macro_use]
     /// extern crate statrs;
     ///
-    /// use std::f64;
+    /// use core::f64;
     /// use statrs::statistics::Statistics;
     ///
     /// # fn main() {

--- a/src/stats_tests/fisher.rs
+++ b/src/stats_tests/fisher.rs
@@ -369,7 +369,7 @@ mod tests {
                 Alternative::TwoSided,
             ]
             .iter()
-            .zip(vec![less_expected, greater_expected, two_sided_expected])
+            .zip([less_expected, greater_expected, two_sided_expected])
             {
                 let p_value = fishers_exact(table, *alternative).unwrap();
                 assert!(prec::almost_eq(p_value, *expected, 1e-12));

--- a/src/stats_tests/fisher.rs
+++ b/src/stats_tests/fisher.rs
@@ -104,9 +104,9 @@ pub enum FishersExactTestError {
     TableInvalidForHypergeometric(HypergeometricError),
 }
 
-impl std::fmt::Display for FishersExactTestError {
+impl core::fmt::Display for FishersExactTestError {
     #[cfg_attr(coverage_nightly, coverage(off))]
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             FishersExactTestError::TableInvalidForHypergeometric(hg_err) => {
                 writeln!(f, "Cannot create a Hypergeometric distribution from the data in the contingency table.")?;

--- a/src/stats_tests/fisher.rs
+++ b/src/stats_tests/fisher.rs
@@ -117,6 +117,7 @@ impl core::fmt::Display for FishersExactTestError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for FishersExactTestError {}
 
 impl From<HypergeometricError> for FishersExactTestError {

--- a/tests/nist_tests.rs
+++ b/tests/nist_tests.rs
@@ -29,7 +29,7 @@ struct TestCase {
 }
 
 impl std::fmt::Debug for TestCase {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "TestCase({:?}, [...]", self.certified)
     }
 }
@@ -41,8 +41,8 @@ struct CertifiedValues {
     corr: f64,
 }
 
-impl std::fmt::Display for CertifiedValues {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for CertifiedValues {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(
             f,
             "μ={:.3e}, σ={:.3e}, r={:.3e}",


### PR DESCRIPTION
Closes #165.

Standard library types that exist in libcore are usually just reexported through `std::`, so changing from e.g. `std::f64` to `core::f64` results in no change in behavior.

There are a few things to note:
- All `nalgebra`-dependent features require std at the moment. I'm not sure `OVector`/`OMatrix` can be used without std because of `Dyn`, but nalgebra does support `no_std` and `SVector`/`SMatrix` should work without libstd. Out of scope here though.
- Some other features also require libstd, so they're disabled in `no_std`. E.g. all functions that have a `Vec` parameter/return type like `OrderStatistics::ranks`.
`core::error::Error` exists, but was only recently stabilized in 1.81.0. I decided to not use this yet and instead not implement the Error trait in `no_std`.
- Tests have worse error messages in no_std. I don't know how to this type of string formatting without `String`, so I just dropped it. Dev machines should usually have it available anyways.