### PR TITLE
feat: accessor methods to various distribution

### DIFF
--- a/src/distribution/dirac.rs
+++ b/src/distribution/dirac.rs
@@ -60,6 +60,20 @@ impl Dirac {
             Ok(Dirac(v))
         }
     }
+
+    /// Returns the value `v` of the dirac distribution
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use statrs::distribution::Dirac;
+    ///
+    /// let n = Dirac::new(3.0).unwrap();
+    /// assert_eq!(n.v(), 3.0);
+    /// ```
+    pub fn v(&self) -> f64 {
+        self.0
+    }
 }
 
 impl std::fmt::Display for Dirac {

--- a/src/distribution/discrete_uniform.rs
+++ b/src/distribution/discrete_uniform.rs
@@ -66,6 +66,44 @@ impl DiscreteUniform {
             Ok(DiscreteUniform { min, max })
         }
     }
+
+    /// Returns the minimum value in the domain of the discrete uniform
+    /// distribution
+    ///
+    /// # Remarks
+    ///
+    /// This is the same value as the minimum passed into the constructor
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use statrs::distribution::DiscreteUniform;
+    ///
+    /// let n = DiscreteUniform::new(0, 5).unwrap();
+    /// assert_eq!(n.min(), 0);
+    /// ```
+    pub fn min(&self) -> i64 {
+        self.min
+    }
+
+    /// Returns the maximum value in the domain of the discrete uniform
+    /// distribution
+    ///
+    /// # Remarks
+    ///
+    /// This is the same value as the maximum passed into the constructor
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use statrs::distribution::DiscreteUniform;
+    ///
+    /// let n = DiscreteUniform::new(0, 5).unwrap();
+    /// assert_eq!(n.max(), 5);
+    /// ```
+    pub fn max(&self) -> i64 {
+        self.max
+    }
 }
 
 impl std::fmt::Display for DiscreteUniform {

--- a/src/distribution/log_normal.rs
+++ b/src/distribution/log_normal.rs
@@ -79,6 +79,34 @@ impl LogNormal {
 
         Ok(LogNormal { location, scale })
     }
+
+    /// Returns the location of the log-normal distribution
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use statrs::distribution::LogNormal;
+    ///
+    /// let n = LogNormal::new(0.0, 1.0).unwrap();
+    /// assert_eq!(n.location(), 0.0);
+    /// ```
+    pub fn location(&self) -> f64 {
+        self.location
+    }
+
+    /// Returns the scale of the log-normal distribution
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use statrs::distribution::LogNormal;
+    ///
+    /// let n = LogNormal::new(0.0, 1.0).unwrap();
+    /// assert_eq!(n.scale(), 1.0);
+    /// ```
+    pub fn scale(&self) -> f64 {
+        self.scale
+    }
 }
 
 impl std::fmt::Display for LogNormal {

--- a/src/distribution/multivariate_normal.rs
+++ b/src/distribution/multivariate_normal.rs
@@ -224,6 +224,66 @@ where
                 .ln(),
         )
     }
+
+    /// Returns the Cholesky decomposition of the covariance matrix
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use nalgebra::OMatrix;
+    /// use statrs::distribution::MultivariateNormal;
+    ///
+    /// let mvn = MultivariateNormal::new(vec![0., 0.], vec![1., 0., 0., 1.]).unwrap();
+    /// assert_eq!(mvn.cov_chol_decomp().shape(), (2, 2));
+    /// ```
+    pub fn cov_chol_decomp(&self) -> &OMatrix<f64, D, D> {
+        &self.cov_chol_decomp
+    }
+
+    /// Returns the mean of the multivariate normal distribution
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use nalgebra::OVector;
+    /// use statrs::distribution::MultivariateNormal;
+    ///
+    /// let mvn = MultivariateNormal::new(vec![0., 0.], vec![1., 0., 0., 1.]).unwrap();
+    /// assert_eq!(mvn.mu(), &OVector::from_vec(vec![0., 0.]));
+    /// ```
+    pub fn mu(&self) -> &OVector<f64, D> {
+        &self.mu
+    }
+
+    /// Returns the mean of the multivariate normal distribution
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use nalgebra::OVector;
+    /// use statrs::distribution::MultivariateNormal;
+    ///
+    /// let mvn = MultivariateNormal::new(vec![0., 0.], vec![1., 0., 0., 1.]).unwrap();
+    /// assert_eq!(mvn.mean(), &OVector::from_vec(vec![0., 0.]));
+    /// ```
+    pub fn cov(&self) -> &OMatrix<f64, D, D> {
+        &self.cov
+    }
+
+    /// Returns the precision matrix of the multivariate normal distribution
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use nalgebra::OMatrix;
+    /// use statrs::distribution::MultivariateNormal;
+    ///
+    /// let mvn = MultivariateNormal::new(vec![0., 0.], vec![1., 0., 0., 1.]).unwrap();
+    /// assert_eq!(mvn.precision().shape(), (2, 2));
+    /// ```
+    pub fn precision(&self) -> &OMatrix<f64, D, D> {
+        &self.precision
+    }
 }
 
 impl<D> std::fmt::Display for MultivariateNormal<D>

--- a/src/distribution/multivariate_normal.rs
+++ b/src/distribution/multivariate_normal.rs
@@ -234,10 +234,10 @@ where
     /// use statrs::distribution::MultivariateNormal;
     ///
     /// let mvn = MultivariateNormal::new(vec![0., 0.], vec![1., 0., 0., 1.]).unwrap();
-    /// assert_eq!(mvn.cov_chol_decomp().shape(), (2, 2));
+    /// assert_eq!(mvn.clone_cov_chol_decomp().shape(), (2, 2));
     /// ```
-    pub fn cov_chol_decomp(&self) -> &OMatrix<f64, D, D> {
-        &self.cov_chol_decomp
+    pub fn clone_cov_chol_decomp(&self) -> OMatrix<f64, D, D> {
+        self.cov_chol_decomp.clone()
     }
 
     /// Returns the mean of the multivariate normal distribution

--- a/src/distribution/multivariate_normal.rs
+++ b/src/distribution/multivariate_normal.rs
@@ -245,26 +245,26 @@ where
     /// # Example
     ///
     /// ```
-    /// use nalgebra::OVector;
+    /// use nalgebra::{OVector, U2};
     /// use statrs::distribution::MultivariateNormal;
     ///
     /// let mvn = MultivariateNormal::new(vec![0., 0.], vec![1., 0., 0., 1.]).unwrap();
-    /// assert_eq!(mvn.mu(), &OVector::from_vec(vec![0., 0.]));
+    /// assert_eq!(mvn.mu(), &OVector::<f64, U2>::from_vec(vec![0., 0.]));
     /// ```
     pub fn mu(&self) -> &OVector<f64, D> {
         &self.mu
     }
 
-    /// Returns the mean of the multivariate normal distribution
+    /// Returns the covariance of the multivariate normal distribution
     ///
     /// # Example
     ///
     /// ```
-    /// use nalgebra::OVector;
+    /// use nalgebra::{OMatrix, U2};
     /// use statrs::distribution::MultivariateNormal;
     ///
     /// let mvn = MultivariateNormal::new(vec![0., 0.], vec![1., 0., 0., 1.]).unwrap();
-    /// assert_eq!(mvn.mean(), &OVector::from_vec(vec![0., 0.]));
+    /// assert_eq!(mvn.cov(), &OMatrix::<f64, U2, U2>::from_vec(vec![1., 0., 0., 1.]));
     /// ```
     pub fn cov(&self) -> &OMatrix<f64, D, D> {
         &self.cov

--- a/src/distribution/triangular.rs
+++ b/src/distribution/triangular.rs
@@ -103,6 +103,44 @@ impl Triangular {
 
         Ok(Triangular { min, max, mode })
     }
+
+    /// Returns the minimum value in the domain of the
+    /// triangular distribution
+    ///
+    /// # Remarks
+    ///
+    /// The return value is the same min used to construct the distribution
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use statrs::distribution::Triangular;
+    ///
+    /// let n = Triangular::new(0.0, 5.0, 2.5).unwrap();
+    /// assert_eq!(n.min(), 0.0);
+    /// ```
+    pub fn min(&self) -> f64 {
+        self.min
+    }
+
+    /// Returns the maximum value in the domain of the
+    /// triangular distribution
+    ///
+    /// # Remarks
+    ///
+    /// The return value is the same max used to construct the distribution
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use statrs::distribution::Triangular;
+    ///
+    /// let n = Triangular::new(0.0, 5.0, 2.5).unwrap();
+    /// assert_eq!(n.max(), 5.0);
+    /// ```
+    pub fn max(&self) -> f64 {
+        self.max
+    }
 }
 
 impl std::fmt::Display for Triangular {

--- a/src/distribution/uniform.rs
+++ b/src/distribution/uniform.rs
@@ -105,6 +105,36 @@ impl Uniform {
     pub fn standard() -> Self {
         Self { min: 0.0, max: 1.0 }
     }
+
+    /// Returns the lower bound of the uniform distribution
+    /// as a `f64`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use statrs::distribution::Uniform;
+    ///
+    /// let uniform = Uniform::new(0.0, 1.0).unwrap();
+    /// assert_eq!(uniform.min(), 0.0);
+    /// ```
+    pub fn min(&self) -> f64 {
+        self.min
+    }
+
+    /// Returns the upper bound of the uniform distribution
+    /// as a `f64`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use statrs::distribution::Uniform;
+    ///
+    /// let uniform = Uniform::new(0.0, 1.0).unwrap();
+    /// assert_eq!(uniform.max(), 1.0);
+    /// ```
+    pub fn max(&self) -> f64 {
+        self.max
+    }
 }
 
 impl Default for Uniform {


### PR DESCRIPTION
Hi, this PR fixes #186. I have implemented the accessor methods for the following distributions,

- [x] Dirac
- [x] Discrete Uniform
- [x] Log Normal
- [x] Triangular
- [x] Uniform
- [x] Multivariate Normal