### PR TITLE
Switched sample to be correct for gamma rate parameterization

### DIFF
--- a/src/distribution/negative_binomial.rs
+++ b/src/distribution/negative_binomial.rs
@@ -141,7 +141,7 @@ impl ::rand::distributions::Distribution<u64> for NegativeBinomial {
     fn sample<R: ::rand::Rng + ?Sized>(&self, r: &mut R) -> u64 {
         use crate::distribution::{gamma, poisson};
 
-        let lambda = gamma::sample_unchecked(r, self.r, (1.0 - self.p) / self.p);
+        let lambda = gamma::sample_unchecked(r, self.r, self.p / (1.0 - self.p));
         poisson::sample_unchecked(r, lambda).floor() as u64
     }
 }


### PR DESCRIPTION
**Description**
The `gamma` call is parameterized to sample using `rate` rather than `scale`. The original input was the scale as a function of `self.p`, leading to unexpected sample behavior. The `sample_unchecked` is now supplied with the rate calculated from `self.p`.