### PR TITLE
Fix broken negative binomial sampling

### DIFF
--- a/src/distribution/negative_binomial.rs
+++ b/src/distribution/negative_binomial.rs
@@ -489,6 +489,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "rand")]
     fn test_sample() {
         use crate::prec;
         use rand::{distributions::Distribution, SeedableRng, rngs::StdRng};


### PR DESCRIPTION
**Description**

The negative binomial distribution sampler is not working because `gamma` is parameterized to sample using `rate` rather than `scale`. The original input was the scale as a function of `self.p` leading to incorrect samples for the specified distribution. The `sample_unchecked` is now supplied with the rate calculated from `self.p` and a test is provided to ensure behavior is in agreement with the theoretical mean and variance of the specified distribution.