### PR TITLE
Fix new `no_std` errors

### DIFF
--- a/src/distribution/dirichlet.rs
+++ b/src/distribution/dirichlet.rs
@@ -369,7 +369,7 @@ where
 mod tests {
     use super::*;
 
-    use std::fmt::{Debug, Display};
+    use core::fmt::{Debug, Display};
 
     use nalgebra::{dmatrix, dvector, vector, DimMin, OVector};
 

--- a/src/distribution/levy.rs
+++ b/src/distribution/levy.rs
@@ -31,9 +31,9 @@ pub enum LevyError {
     ScaleInvalid,
 }
 
-impl std::fmt::Display for LevyError {
+impl core::fmt::Display for LevyError {
     #[cfg_attr(coverage_nightly, coverage(off))]
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             LevyError::LocationInvalid => write!(f, "location is NaN or infinite"),
             LevyError::ScaleInvalid => write!(f, "scale is NaN, infinite or nonpositive"),
@@ -100,8 +100,8 @@ impl Levy {
     }
 }
 
-impl std::fmt::Display for Levy {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl core::fmt::Display for Levy {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         write!(f, "Levy(mu = {}, c = {})", self.mu, self.c)
     }
 }

--- a/src/distribution/levy.rs
+++ b/src/distribution/levy.rs
@@ -41,6 +41,7 @@ impl core::fmt::Display for LevyError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for LevyError {}
 
 impl Levy {

--- a/src/distribution/negative_binomial.rs
+++ b/src/distribution/negative_binomial.rs
@@ -490,7 +490,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "rand")]
+    #[cfg(all(feature = "rand", feature = "std"))]
     fn test_sample() {
         use crate::prec;
         use rand::{distributions::Distribution, SeedableRng, rngs::StdRng};

--- a/src/stats_tests/chisquare.rs
+++ b/src/stats_tests/chisquare.rs
@@ -32,6 +32,7 @@ impl core::fmt::Display for ChiSquareTestError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for ChiSquareTestError {}
 
 /// Perform a Pearson's chi-square test

--- a/src/stats_tests/chisquare.rs
+++ b/src/stats_tests/chisquare.rs
@@ -15,9 +15,9 @@ pub enum ChiSquareTestError {
     DdofInvalid,
 }
 
-impl std::fmt::Display for ChiSquareTestError {
+impl core::fmt::Display for ChiSquareTestError {
     #[cfg_attr(coverage_nightly, coverage(off))]
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             ChiSquareTestError::FObsInvalid => {
                 write!(f, "`f_obs` must have a length greater than 1")

--- a/src/stats_tests/f_oneway.rs
+++ b/src/stats_tests/f_oneway.rs
@@ -18,9 +18,9 @@ pub enum FOneWayTestError {
     SampleContainsNaN,
 }
 
-impl std::fmt::Display for FOneWayTestError {
+impl core::fmt::Display for FOneWayTestError {
     #[cfg_attr(coverage_nightly, coverage(off))]
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             FOneWayTestError::NotEnoughSamples => write!(f, "must be at least two samples"),
             FOneWayTestError::SampleTooSmall => {

--- a/src/stats_tests/ks_test.rs
+++ b/src/stats_tests/ks_test.rs
@@ -27,9 +27,9 @@ pub enum KSTestError {
     ExactAndTooLarge,
 }
 
-impl std::fmt::Display for KSTestError {
+impl core::fmt::Display for KSTestError {
     #[cfg_attr(coverage_nightly, coverage(off))]
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             KSTestError::SampleTooSmall => write!(f, "sample must be len > 1"),
             KSTestError::SampleContainsNaN => {

--- a/src/stats_tests/mannwhitneyu.rs
+++ b/src/stats_tests/mannwhitneyu.rs
@@ -19,9 +19,9 @@ pub enum MannWhitneyUError {
     ExactMethodWithTiesInData,
 }
 
-impl std::fmt::Display for MannWhitneyUError {
+impl core::fmt::Display for MannWhitneyUError {
     #[cfg_attr(coverage_nightly, coverage(off))]
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             MannWhitneyUError::UncomparableData => {
                 write!(f, "elements in the data are not comparable")

--- a/src/stats_tests/mod.rs
+++ b/src/stats_tests/mod.rs
@@ -1,9 +1,15 @@
+#[cfg(feature = "std")]
 pub mod chisquare;
+#[cfg(feature = "std")]
 pub mod f_oneway;
 pub mod fisher;
+#[cfg(feature = "std")]
 pub mod ks_test;
+#[cfg(feature = "std")]
 pub mod mannwhitneyu;
+#[cfg(feature = "std")]
 pub mod skewtest;
+#[cfg(feature = "std")]
 pub mod ttest_onesample;
 
 /// Specifies an [alternative hypothesis](https://en.wikipedia.org/wiki/Alternative_hypothesis)

--- a/src/stats_tests/skewtest.rs
+++ b/src/stats_tests/skewtest.rs
@@ -31,6 +31,7 @@ impl core::fmt::Display for SkewTestError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for SkewTestError {}
 
 fn calc_root_b1(data: &[f64]) -> f64 {

--- a/src/stats_tests/skewtest.rs
+++ b/src/stats_tests/skewtest.rs
@@ -14,9 +14,9 @@ pub enum SkewTestError {
     SampleContainsNaN,
 }
 
-impl std::fmt::Display for SkewTestError {
+impl core::fmt::Display for SkewTestError {
     #[cfg_attr(coverage_nightly, coverage(off))]
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             SkewTestError::SampleTooSmall => {
                 write!(f, "sample must contain at least 8 observations")

--- a/src/stats_tests/ttest_onesample.rs
+++ b/src/stats_tests/ttest_onesample.rs
@@ -14,9 +14,9 @@ pub enum TTestOneSampleError {
     SampleContainsNaN,
 }
 
-impl std::fmt::Display for TTestOneSampleError {
+impl core::fmt::Display for TTestOneSampleError {
     #[cfg_attr(coverage_nightly, coverage(off))]
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             TTestOneSampleError::SampleTooSmall => write!(f, "sample must be len > 1"),
             TTestOneSampleError::SampleContainsNaN => {

--- a/src/stats_tests/ttest_onesample.rs
+++ b/src/stats_tests/ttest_onesample.rs
@@ -29,6 +29,7 @@ impl core::fmt::Display for TTestOneSampleError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for TTestOneSampleError {}
 
 /// Perform a one sample t-test

--- a/tests/nist_tests.rs
+++ b/tests/nist_tests.rs
@@ -28,7 +28,7 @@ struct TestCase {
     values: Vec<f64>,
 }
 
-impl std::fmt::Debug for TestCase {
+impl core::fmt::Debug for TestCase {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "TestCase({:?}, [...]", self.certified)
     }


### PR DESCRIPTION
Fixes the errors introduced by #314. These are just the lowest effort way to get it to compile in `no_std` again, some of the new code can maybe be rewritten to become `no_std`-compatible. This should allow `master` to pass CI again though.