### PR TITLE
fix: Triangular::pdf returns NaN when mode equals min

### DIFF
--- a/src/distribution/triangular.rs
+++ b/src/distribution/triangular.rs
@@ -398,10 +398,6 @@ impl Continuous<f64, f64> for Triangular {
         let c = self.mode;
         if a <= x && x <= c {
             if c == a {
-                // The only `x` reaching this branch is `x == min == mode`, where the
-                // rising edge is degenerate and the expression below is 0 / 0. The
-                // density there is the height of the triangle, matching the value the
-                // falling edge already returns for the mirrored `mode == max` case.
                 2.0 / (b - a)
             } else {
                 2.0 * (x - a) / ((b - a) * (c - a))
@@ -559,12 +555,15 @@ mod tests {
         test_exact(-5.0, -3.0, -4.0, 0.5, pdf(-4.5));
         test_exact(-5.0, -3.0, -4.0, 1.0, pdf(-4.0));
         test_exact(-5.0, -3.0, -4.0, 0.5, pdf(-3.5));
-        // mode == min: the rising edge is degenerate at x == min, the density there
-        // is the height of the triangle
+    }
+
+    #[test]
+    fn test_pdf_mode_at_an_endpoint() {
+        let pdf = |arg: f64| move |x: Triangular| x.pdf(arg);
         test_exact(0.0, 1.0, 0.0, 2.0, pdf(0.0));
         test_exact(-2.0, 5.0, -2.0, 2.0 / 7.0, pdf(-2.0));
-        // mirrored case, mode == max
         test_exact(0.0, 1.0, 1.0, 2.0, pdf(1.0));
+        test_exact(-2.0, 5.0, 5.0, 2.0 / 7.0, pdf(5.0));
     }
 
     #[test]
@@ -585,8 +584,14 @@ mod tests {
         test_exact(-5.0, -3.0, -4.0, 0.5f64.ln(), ln_pdf(-4.5));
         test_exact(-5.0, -3.0, -4.0, 0.0, ln_pdf(-4.0));
         test_exact(-5.0, -3.0, -4.0, 0.5f64.ln(), ln_pdf(-3.5));
+    }
+
+    #[test]
+    fn test_ln_pdf_mode_at_an_endpoint() {
+        let ln_pdf = |arg: f64| move |x: Triangular| x.ln_pdf(arg);
         test_exact(0.0, 1.0, 0.0, 2f64.ln(), ln_pdf(0.0));
         test_exact(-2.0, 5.0, -2.0, (2.0f64 / 7.0).ln(), ln_pdf(-2.0));
+        test_exact(0.0, 1.0, 1.0, 2f64.ln(), ln_pdf(1.0));
     }
 
     #[test]

--- a/src/distribution/triangular.rs
+++ b/src/distribution/triangular.rs
@@ -388,12 +388,24 @@ impl Continuous<f64, f64> for Triangular {
     ///     0
     /// }
     /// ```
+    ///
+    /// When `mode == min` the second branch is degenerate and reduces to `0 / 0`;
+    /// the density at that single point is the height of the triangle,
+    /// `2 / (max - min)`.
     fn pdf(&self, x: f64) -> f64 {
         let a = self.min;
         let b = self.max;
         let c = self.mode;
         if a <= x && x <= c {
-            2.0 * (x - a) / ((b - a) * (c - a))
+            if c == a {
+                // The only `x` reaching this branch is `x == min == mode`, where the
+                // rising edge is degenerate and the expression below is 0 / 0. The
+                // density there is the height of the triangle, matching the value the
+                // falling edge already returns for the mirrored `mode == max` case.
+                2.0 / (b - a)
+            } else {
+                2.0 * (x - a) / ((b - a) * (c - a))
+            }
         } else if c < x && x <= b {
             2.0 * (b - x) / ((b - a) * (b - c))
         } else {
@@ -547,6 +559,12 @@ mod tests {
         test_exact(-5.0, -3.0, -4.0, 0.5, pdf(-4.5));
         test_exact(-5.0, -3.0, -4.0, 1.0, pdf(-4.0));
         test_exact(-5.0, -3.0, -4.0, 0.5, pdf(-3.5));
+        // mode == min: the rising edge is degenerate at x == min, the density there
+        // is the height of the triangle
+        test_exact(0.0, 1.0, 0.0, 2.0, pdf(0.0));
+        test_exact(-2.0, 5.0, -2.0, 2.0 / 7.0, pdf(-2.0));
+        // mirrored case, mode == max
+        test_exact(0.0, 1.0, 1.0, 2.0, pdf(1.0));
     }
 
     #[test]
@@ -567,6 +585,8 @@ mod tests {
         test_exact(-5.0, -3.0, -4.0, 0.5f64.ln(), ln_pdf(-4.5));
         test_exact(-5.0, -3.0, -4.0, 0.0, ln_pdf(-4.0));
         test_exact(-5.0, -3.0, -4.0, 0.5f64.ln(), ln_pdf(-3.5));
+        test_exact(0.0, 1.0, 0.0, 2f64.ln(), ln_pdf(0.0));
+        test_exact(-2.0, 5.0, -2.0, (2.0f64 / 7.0).ln(), ln_pdf(-2.0));
     }
 
     #[test]
@@ -640,5 +660,7 @@ mod tests {
     fn test_continuous() {
         density_util::check_continuous_distribution(&create_ok(-5.0, 5.0, 0.0), -5.0, 5.0);
         density_util::check_continuous_distribution(&create_ok(-15.0, -2.0, -3.0), -15.0, -2.0);
+        density_util::check_continuous_distribution(&create_ok(-5.0, 5.0, -5.0), -5.0, 5.0);
+        density_util::check_continuous_distribution(&create_ok(-5.0, 5.0, 5.0), -5.0, 5.0);
     }
 }

--- a/src/distribution/triangular.rs
+++ b/src/distribution/triangular.rs
@@ -388,10 +388,6 @@ impl Continuous<f64, f64> for Triangular {
     ///     0
     /// }
     /// ```
-    ///
-    /// When `mode == min` the second branch is degenerate and reduces to `0 / 0`;
-    /// the density at that single point is the height of the triangle,
-    /// `2 / (max - min)`.
     fn pdf(&self, x: f64) -> f64 {
         let a = self.min;
         let b = self.max;


### PR DESCRIPTION
`Triangular::new` accepts `mode == min` (a right triangle) — `test_create` already covers it with `create_ok(1.0, 2.0, 1.0)`. But `pdf` evaluates the rising edge as `2 * (x - min) / ((max - min) * (mode - min))`, and at `x == min == mode` both the numerator and the `(mode - min)` factor are zero, so the result is `0 / 0` = NaN. `ln_pdf` delegates to `pdf` and returns NaN as well.

```rust
let d = Triangular::new(0.0, 1.0, 0.0).unwrap();
d.pdf(0.0);     // NaN, expected 2.0
d.ln_pdf(0.0);  // NaN, expected ln(2)
```

The mirrored `mode == max` case is already correct: `pdf` takes the same first branch and returns `2 / (max - min)`, the height of the triangle. This handles the degenerate rising edge so both endpoints agree.

`x == min == mode` is the only `x` that can reach that branch when `mode == min`, so no other input changes value. Added `pdf`/`ln_pdf` cases for both endpoint modes and extended `test_continuous` to cover them; both new assertions fail on `main` with NaN.

Kept deliberately minimal since you mentioned in #352 that review bandwidth is the bottleneck.

Disclosure: this was AI assisted. An agent ran a differential sweep of the distributions against mpmath at 60 digits, which is what surfaced this, and drafted the patch; I verified the result and the reasoning before submitting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed triangular distribution calculations when the mode equals the minimum value.
  - Prevented invalid results at the distribution’s rising-edge boundary.
  - Improved reliability for probability density and log-density calculations in this edge case.

- **Tests**
  - Added coverage for minimum-mode endpoint behavior.
  - Verified accurate density and log-density results.
  - Expanded validation of continuous distribution behavior at endpoint modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->