### PR TITLE
Return None from Empirical::variance for a single sample

### DIFF
--- a/src/distribution/empirical.rs
+++ b/src/distribution/empirical.rs
@@ -243,7 +243,8 @@ impl Distribution<f64> for Empirical {
     }
 
     fn variance(&self) -> Option<f64> {
-        if self.data.is_empty() {
+        // The `n - 1` denominator is zero for a single sample, so the sample variance is undefined.
+        if self.sum < 2 {
             None
         } else {
             Some(self.var / (self.sum as f64 - 1.))
@@ -344,6 +345,12 @@ mod tests {
 
         let dist = Empirical::from_iter(vec![]);
         assert!(dist.variance().is_none());
+
+        // A single sample has no `n - 1` denominator; the sample variance is undefined.
+        let one = Empirical::from_iter(vec![4.0]);
+        assert!(one.variance().is_none());
+        assert!(one.std_dev().is_none());
+        test_var_for_samples(2.0, vec![1.0, 3.0]);
 
         test_var_for_samples(0.0, vec![4.0; 100]);
         test_var_for_samples(0.0, vec![-0.2; 100]);


### PR DESCRIPTION
`Empirical::variance()` returns `Some(NaN)` for a single sample.

```
n=0   variance=None          std_dev=None
n=1   variance=Some(NaN)     std_dev=Some(NaN)
n=2   variance=Some(2.0)     std_dev=Some(1.4142135623730951)
n=100 variance=Some(0.0)     std_dev=Some(0.0)
```

`src/distribution/empirical.rs:245` guards emptiness while the denominator is `n - 1`:

```rust
fn variance(&self) -> Option<f64> {
    if self.data.is_empty() {
        None
    } else {
        Some(self.var / (self.sum as f64 - 1.))
    }
}
```

At `n == 1` the denominator is zero and `self.var` is zero too, so it is `0.0 / 0.0`. `std_dev()` is
the default trait method `variance().map(f64::sqrt)`, so the NaN reaches a second public method.

`Option` is already this crate's channel for "undefined here" - it is what `n == 0` returns.

### The siblings guard the denominator, not emptiness

- `src/statistics/online.rs:52`, `OnlineMoments<2>::variance` - `if self.count < 2 { None }`, and its
  doc says so outright: *"or `None` if fewer than two observations have been pushed"*
- `src/statistics/online.rs:95`, `OnlineMoments<3>::variance` - the same
- `src/distribution/hypergeometric.rs:332` - `if self.population <= 1 { None }`

`Empirical` is the one that checks the wrong thing.

### The change

`self.data.is_empty()` becomes `self.sum < 2`. The struct's own invariant at `empirical.rs:62` -
*"Must be 0 iff data.is_empty()"* - means the new predicate subsumes the old one, so `n == 0` is
unchanged.

**Observable change, plainly:** `Empirical::from_iter([x]).variance()` goes from `Some(NaN)` to
`None`, and `.std_dev()` with it. Nothing else moves - `n == 0` and `n >= 2` are identical, and the
test below pins that from both sides.

### Tests

Three lines added to the existing `test_var`, which covered `vec![]` and `vec![4.0; 100]` but never
`n == 1`. Reverting only the guard:

```
thread 'distribution::empirical::tests::test_var' panicked at src/distribution/empirical.rs:350:9:
assertion failed: one.variance().is_none()
test result: FAILED. 8 passed; 1 failed
```

I also mutation-checked the guard itself, because my first draft was not tight enough:

- `self.sum < 1` (the old empty-only guard, restated) -> `test_var` FAILS
- `self.sum < 3` (over-guarding `n == 2`) -> `test_var` FAILS

The second only started failing after I added `test_var_for_samples(2.0, vec![1.0, 3.0])` to pin
`n == 2` from the other side. `2.0` is exact in binary floating point, so that assertion is not
rounding-direction dependent.

CI gates: `cargo fmt -- --check` clean, `cargo clippy --all-targets -- -D warnings` clean,
`cargo test` gives `833 passed; 0 failed; 2 ignored` and `195 passed; 0 failed`.

### Related

#460 (`Triangular::pdf` returning NaN when mode equals min) fixed the same `0/0`-reaching-the-caller
class in this crate last week.

---

Disclosure: found and prepared with AI assistance (Claude). Every figure above is from a run on this
branch, and the sibling comparison and mutation checks are mine, not a summary of a tool's output.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Variance and standard deviation are now reported as undefined when a distribution contains fewer than two samples, avoiding invalid single-sample results.
* **Tests**
  * Added coverage for single-sample distributions to verify the corrected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->