### PR TITLE
fix: sample Gumbel via -ln(U), not ln(-U)

### DIFF
--- a/src/distribution/gumbel.rs
+++ b/src/distribution/gumbel.rs
@@ -118,7 +118,7 @@ impl core::fmt::Display for Gumbel {
 impl ::rand::distr::Distribution<f64> for Gumbel {
     fn sample<R: rand::Rng + ?Sized>(&self, r: &mut R) -> f64 {
         let x = ::rand::RngExt::random::<f64>(r);
-        self.location - self.scale * ((-x).ln()).ln()
+        self.location - self.scale * (-x.ln()).ln()
     }
 }
 
@@ -354,6 +354,19 @@ mod tests {
         create_ok(10.0, 11.0);
         create_ok(-5.0, 100.0);
         create_ok(0.0, f64::INFINITY);
+    }
+
+    #[test]
+    #[cfg(feature = "rand")]
+    fn test_sample() {
+        use rand::{distr::Distribution as _, rngs::StdRng, SeedableRng};
+
+        let mut rng = StdRng::seed_from_u64(437);
+        let n = create_ok(0.0, 1.0);
+        for _ in 0..20 {
+            let s = n.sample(&mut rng);
+            assert!(s.is_finite(), "sample was {s}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
`Gumbel::sample` is inverse transform sampling, so it should be the same map as `inverse_cdf`: `μ - β ln(-ln(U))` for `U ~ Uniform(0, 1)`. It was written as `((-x).ln()).ln()` instead of `(-x.ln()).ln()`. `x` is in `[0, 1)`, so `-x` is negative and `ln(-x)` is NaN on every draw.

```
Gumbel::new(0.0, 1.0).unwrap().sample(&mut rng)  // NaN
```

`cdf`, `inverse_cdf`, and the moments were already finite for the same parameters. The parentheses just sat on the wrong operand; `inverse_cdf` already had the right grouping.

`test_sample` is the same shape as Cauchy's: 20 draws from a seeded `StdRng` must be finite. It failed on main with `sample was NaN` and passes with the grouping fixed.

`cargo test` is green (834 lib + 195 doctests), as are `cargo fmt -- --check`, clippy under `-Dwarnings`, and `cargo check --no-default-features --lib`.

Fixes #461


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected Gumbel distribution sampling to produce valid finite values for positive random inputs.
  - Improved reliability of generated samples across repeated sampling operations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->